### PR TITLE
fix: HF_TOKEN env var ignored by the Klein download prompt

### DIFF
--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -13041,9 +13041,13 @@ class LoRATrainerGUI:
         if family == "klein":
             # Klein's repos are gated: BFL require each user to accept the licence themselves,
             # which is exactly why these can't be bundled or pre-fetched on anyone's behalf.
-            token = self._ask_hf_token()
+            # An HF_TOKEN already in the environment (the container's documented env var for
+            # exactly this) satisfies the gate with no prompt — only ask when there isn't one.
+            token = os.environ.get("HF_TOKEN", "").strip()
             if not token:
-                return
+                token = self._ask_hf_token()
+                if not token:
+                    return
 
         btn = getattr(self, f"_fetch_btn_{family}", None)
         status = getattr(self, f"_fetch_status_{family}", None)


### PR DESCRIPTION
Hey,

Small one — Preferences → "Download models for me" → Klein always pops the interactive
HuggingFace token dialog, even when `HF_TOKEN` is already sitting in the environment. That's
exactly the variable the container docs tell people to set for this, so on a RunPod/Vast pod
it was prompting every single time instead of just working.

This just checks the environment first and only asks when it's actually empty. Verified
headless (Xvfb): dialog gets skipped when `HF_TOKEN` is set, and still shows up normally when
it's not, so nothing changes for anyone using it interactively.

Cheers,
FNG