### PR TITLE
feat: optional SSH via PUBLIC_KEY, for hosts that don't inject it themselves

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libgl1 libglib2.0-0 libsm6 libxext6 libxrender1 \
       fonts-dejavu-core fonts-liberation fontconfig unzip \
       xdg-utils pcmanfm dbus-x11 \
+      openssh-server \
     && rm -rf /var/lib/apt/lists/*
+# openssh-server sits here unused unless PUBLIC_KEY is set at boot (see entrypoint.sh) — the
+# file manager + runpodctl remain the default, keyless transfer path. This is for anyone who
+# wants a real shell for debugging: RunPod's own "SSH Terminal Access" toggle sets PUBLIC_KEY
+# for you, so opting in there wires this up with no template changes; anywhere else, set
+# PUBLIC_KEY to your own public key. Off by default: no open port 22 for someone who never asked.
 # gcc + libc6-dev are RUNTIME dependencies, not builder leftovers: torch.compile has
 # inductor/triton build small host-side C stubs while training runs, and without a compiler
 # every compiled run died with "Failed to find C compiler". The app now declines compile
@@ -212,9 +218,10 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # noVNC over HTTP — the only port that needs exposing. 5900 stays internal on purpose: raw VNC
 # is unencrypted, and the host's HTTPS proxy is what makes this safe to reach over the internet.
-# 8081 is reserved for the app to serve on (a phone-facing run monitor). Declaring it here
-# is documentation — RunPod exposes what the TEMPLATE lists — but it keeps the ports in
-# one place and works for a plain `docker run -p`.
-EXPOSE 6080 8080 8081
+# 8081 is reserved for the app to serve on (a phone-facing run monitor). 22 only ever listens
+# if PUBLIC_KEY is set (see entrypoint.sh) — declaring it here is documentation, same as 8081.
+# Declaring these is documentation — RunPod exposes what the TEMPLATE lists — but it keeps the
+# ports in one place and works for a plain `docker run -p`.
+EXPOSE 6080 8080 8081 22
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,6 +48,30 @@ echo -e "${VNC_PASSWORD}
 ${VNC_PASSWORD}
 " | kasmvncpasswd -u fizgig -w -o /root/.kasmpasswd >/dev/null 2>&1
 
+# ---------------------------------------------------------------- optional SSH
+# Off by default — the file manager + runpodctl are the transfer path this image is built
+# around, and an image that opens port 22 for everyone regardless of whether they asked is a
+# worse default than a debugging feature nobody but us used. PUBLIC_KEY is RunPod's OWN
+# convention (their "SSH Terminal Access" toggle sets it for you), so opting in there wires
+# this up for free; on any other host, set PUBLIC_KEY to your public key yourself.
+if [ -n "${PUBLIC_KEY:-}" ]; then
+  # Self-installing so this also works against an already-published image that predates
+  # openssh-server being baked in (see Dockerfile) — a no-op once a newer image has it.
+  if ! command -v sshd >/dev/null 2>&1; then
+    log "PUBLIC_KEY set — installing openssh-server"
+    apt-get update -qq && apt-get install -y --no-install-recommends openssh-server -qq
+  fi
+  mkdir -p /root/.ssh
+  echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
+  chmod 700 /root/.ssh
+  chmod 600 /root/.ssh/authorized_keys
+  # PasswordAuthentication stays default (no) — a key was just handed to us, a password wasn't,
+  # and this is root on a box reachable from the whole internet.
+  mkdir -p /run/sshd
+  /usr/sbin/sshd
+  log "SSH enabled on :22 (PUBLIC_KEY was set)"
+fi
+
 # ---------------------------------------------------------------- Fizgig source
 # Pulled rather than baked, so a new release needs no image rebuild. A pod restart is an update.
 if [ -d "$APP_DIR/.git" ]; then


### PR DESCRIPTION
Hey,

Was poking around on Vast.ai and found there's no way to get a real shell into the pod — this
image never installs or starts an sshd, so mapping port 22 gets you "connection refused" no
matter what. Looks deliberate (the runpodctl comment even calls out "no ports to open, no SSH
keys" as the point), and it's a fine default, but it made debugging a real pain.

RunPod's own Connect/Web Terminal still works fine regardless, since that's handled
platform-side, not by anything in the image. This is for Vast and anywhere else — added
openssh-server, and it only ever starts if `PUBLIC_KEY` is set (same env var RunPod's own SSH
toggle already uses, so turning that on over there wires this up for free). It also
self-installs at boot if the image predates this change, so it doesn't need a fresh image
build to start working. Off by default — no open port 22 for anyone who didn't ask for one,
and it's key-only (no password auth).

Verified locally with podman + GPU passthrough: PUBLIC_KEY set → installs, starts, accepts the
matching key. Unset → connection reset, nothing listening at all.

Cheers,
FNG