### PR TITLE
docs: file manager password isn't always "the same one" as VNC_PASSWORD

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,7 +61,7 @@ You're in business when the log reaches:
 | | Port | Username | Password |
 |---|---|---|---|
 | **Fizgig** | 6080 | `fizgig` | your `VNC_PASSWORD` |
-| **File manager** | 8080 | `admin` | the same one |
+| **File manager** | 8080 | `admin` | the same one, zero-padded to 12 chars if shorter — see below |
 
 **Set your own password when you deploy.** On the deploy screen expand **Edit Template →
 Environment Variables**, add `VNC_PASSWORD`, and pick something 12+ characters. Then you already

--- a/docs/RUNPOD_TEMPLATE.md
+++ b/docs/RUNPOD_TEMPLATE.md
@@ -51,7 +51,7 @@ Both ports then ask for a username and password:
 | | Port | Username | Password |
 |---|---|---|---|
 | **Fizgig** | 6080 | `fizgig` | your `VNC_PASSWORD` |
-| **File manager** | 8080 | `admin` | the same one |
+| **File manager** | 8080 | `admin` | the same one, zero-padded to 12 chars if shorter — see below |
 
 **Set your own password when you deploy** — it saves you hunting for one later. On the deploy
 screen expand **Edit Template → Environment Variables**, add `VNC_PASSWORD`, and pick something


### PR DESCRIPTION
Hey,

Small docs fix. The quick-reference table says the file manager uses `admin` / "the same one"
as `VNC_PASSWORD`. That's only true when `VNC_PASSWORD` is 12+ characters — shorter ones get
zero-padded for the file manager, which requires 12. The explanation was already a few lines
down, but the table itself is exactly the spot someone skims first and gets stuck — which is
what happened to me testing this.

Just tweaked the table cell to point at the padding note instead of overpromising. No code
changes.

Cheers,
FNG