### PR TITLE
fix: pin Florence-2's revision instead of trusting main at request time

### DIFF
--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -601,6 +601,16 @@ _FIZGIG_DIR = os.path.dirname(os.path.abspath(__file__))
 # file comes from, not who it is for.
 FLORENCE_DEFAULT_MODEL = "MiaoshouAI/Florence-2-base-PromptGen"
 FLORENCE_MODELS = [FLORENCE_DEFAULT_MODEL, "microsoft/Florence-2-base", "microsoft/Florence-2-large"]
+# Florence-2 isn't a native transformers architecture, so loading it means trust_remote_code=True
+# — downloading and EXECUTING whatever Python is currently on that repo's default branch, with no
+# pin. Pinned here to the commit each was audited against, so a compromised account (or a repo
+# that just changes later) can't silently change what gets executed on someone's next first-run.
+# To refresh a pin: check https://huggingface.co/api/models/<repo> for the current "sha".
+FLORENCE_REVISIONS = {
+    "MiaoshouAI/Florence-2-base-PromptGen": "da7ac9f3deac56a928e2fd4d94d8bb985d231299",
+    "microsoft/Florence-2-base": "5ca5edf5bd017b9919c05d08aebef5e4c7ac3bac",
+    "microsoft/Florence-2-large": "21a599d414c4d928c9032694c424fb94458e3594",
+}
 FLORENCE_TASKS = ["<CAPTION>", "<DETAILED_CAPTION>", "<MORE_DETAILED_CAPTION>"]
 QWEN_CAPTION_MODEL = "Qwen3-VL 4B (Krea 2 text encoder)"
 QWEN_CUSTOM_TASK = "Custom…"
@@ -6300,9 +6310,11 @@ class LoRATrainerGUI:
             self.master.update_idletasks()
 
             from fizgig.utils.hf_cache import from_pretrained_cache_first
+            florence_revision = FLORENCE_REVISIONS.get(model_name)
             self.florence_processor = from_pretrained_cache_first(
                 AutoProcessor,
                 model_name,
+                revision=florence_revision,
                 trust_remote_code=True
             )
 
@@ -6316,6 +6328,7 @@ class LoRATrainerGUI:
             self.florence_model = from_pretrained_cache_first(
                 AutoModelForCausalLM,
                 model_name,
+                revision=florence_revision,
                 torch_dtype=torch.float16 if device == "cuda" else torch.float32,
                 trust_remote_code=True,
                 attn_implementation="eager"

--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -611,6 +611,16 @@ FLORENCE_REVISIONS = {
     "microsoft/Florence-2-base": "5ca5edf5bd017b9919c05d08aebef5e4c7ac3bac",
     "microsoft/Florence-2-large": "21a599d414c4d928c9032694c424fb94458e3594",
 }
+# PromptGen's config doesn't carry its own modeling code — its auto_map points at
+# "microsoft/Florence-2-base-ft--modeling_florence2...", so transformers fetches the code that
+# actually EXECUTES from that second, different repo. Our `revision` above only pins PromptGen
+# itself; transformers only carries it over to the code repo automatically when the two repos
+# are the same one (they aren't here), so the redirected repo needs its own explicit pin via
+# code_revision or it silently stays on "main". The two microsoft/ models don't redirect
+# (their auto_map has no repo prefix, just the module path), so they don't need an entry here.
+FLORENCE_CODE_REVISIONS = {
+    "MiaoshouAI/Florence-2-base-PromptGen": "f6c1a25888ffc1d945ee8a1a77ac833c7303d46e",  # microsoft/Florence-2-base-ft
+}
 FLORENCE_TASKS = ["<CAPTION>", "<DETAILED_CAPTION>", "<MORE_DETAILED_CAPTION>"]
 QWEN_CAPTION_MODEL = "Qwen3-VL 4B (Krea 2 text encoder)"
 QWEN_CUSTOM_TASK = "Custom…"
@@ -6311,10 +6321,12 @@ class LoRATrainerGUI:
 
             from fizgig.utils.hf_cache import from_pretrained_cache_first
             florence_revision = FLORENCE_REVISIONS.get(model_name)
+            florence_code_revision = FLORENCE_CODE_REVISIONS.get(model_name)
             self.florence_processor = from_pretrained_cache_first(
                 AutoProcessor,
                 model_name,
                 revision=florence_revision,
+                code_revision=florence_code_revision,
                 trust_remote_code=True
             )
 
@@ -6329,6 +6341,7 @@ class LoRATrainerGUI:
                 AutoModelForCausalLM,
                 model_name,
                 revision=florence_revision,
+                code_revision=florence_code_revision,
                 torch_dtype=torch.float16 if device == "cuda" else torch.float32,
                 trust_remote_code=True,
                 attn_implementation="eager"


### PR DESCRIPTION
Hey,

Florence-2 isn't a native transformers architecture, so loading it goes through
`trust_remote_code=True` — which downloads and executes whatever Python is currently sitting on
that repo's default branch. Nothing pins it to a known-good commit right now, so a compromised
maintainer account (or just the repo changing later) would silently change what gets executed
on the next first-run on anyone's machine.

Pinned all three selectable models (the default `MiaoshouAI/Florence-2-base-PromptGen` plus the
two `microsoft/` fallbacks) to the commit each was checked against, with a comment on how to
refresh the pin later via the HF API.

Cheers,
FNG