### PR TITLE
fix: entrypoint silently kept stale code on a bad FIZGIG_REPO/FIZGIG_REF

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,7 +52,21 @@ ${VNC_PASSWORD}
 # Pulled rather than baked, so a new release needs no image rebuild. A pod restart is an update.
 if [ -d "$APP_DIR/.git" ]; then
   log "Updating Fizgig in $APP_DIR"
-  git -C "$APP_DIR" fetch --depth 1 origin "$REPO_REF" && git -C "$APP_DIR" reset --hard FETCH_HEAD
+  # A persistent volume can carry a checkout from a DIFFERENT FIZGIG_REPO than the one
+  # configured now (switched forks, fixed a typo) — origin is whatever the ORIGINAL clone
+  # set it to, so point it at the current URL before fetching, or the ref lookup silently
+  # targets the wrong repo.
+  git -C "$APP_DIR" remote set-url origin "$REPO_URL"
+  # NOT `fetch && reset` as one statement: under `set -e`, a failing command is only fatal
+  # as the LAST command in an && chain — bash's own documented errexit exemption for
+  # everything before it. A bad FIZGIG_REF used to fail the fetch, skip the reset, and
+  # carry on running whatever was already checked out, with nothing but a bare `fatal:`
+  # line (no [fizgig] prefix, nothing that reads as an error) to show for it.
+  if ! git -C "$APP_DIR" fetch --depth 1 origin "$REPO_REF" \
+      || ! git -C "$APP_DIR" reset --hard FETCH_HEAD; then
+    log "ERROR: could not update to '$REPO_REF' from $REPO_URL — check FIZGIG_REPO/FIZGIG_REF for a typo."
+    log "       Continuing on whatever was already checked out ($(git -C "$APP_DIR" rev-parse --short HEAD 2>/dev/null))."
+  fi
 else
   log "Cloning Fizgig ($REPO_REF)"
   git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$APP_DIR"


### PR DESCRIPTION
Hey,

Found this while testing against a persistent volume that already had a checkout from a
previous boot. A volume can carry a checkout pointed at a different `FIZGIG_REPO` than the one
configured now — say, switching to a fork, or just fixing a typo in `FIZGIG_REF` — but `origin`
is still whatever the ORIGINAL clone set it to. So the `git fetch origin $REPO_REF` on the
"already have a checkout" path was targeting the wrong remote entirely, and failing.

That failure went completely unnoticed. Under `set -e`, a failing command is only fatal as the
LAST command in an `&&` chain — that's bash's own documented errexit exemption for everything
before it. So the fetch failed, the reset never ran, and the pod just kept going on whatever
was already checked out, with nothing but a bare `fatal:` line in the log (no `[fizgig]`
prefix, nothing that reads as an error) to show for it. Anyone who ever changes `FIZGIG_REPO`
or `FIZGIG_REF` after their first boot on a given volume would hit this and have no idea their
update never took effect.

Fix points `origin` at the current `FIZGIG_REPO` before fetching, and logs loudly instead of
carrying on silently when the update fails.

Verified live: recreated a pod against a workspace with a stale `origin` pointed at a different
repo, and it now correctly re-points and checks out the requested ref. Before the fix it
silently kept running the old checkout instead.

Cheers,
FNG