### PR TITLE
feat: rich safetensors metadata — trigger phrase, thumbnail, always-on modelspec

### DIFF
--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -1078,6 +1078,8 @@ class LoRATrainerGUI:
             "METADATA_DESCRIPTION": "",
             "METADATA_LICENSE": "",
             "METADATA_TAGS": "",
+            "METADATA_TRIGGER_PHRASE": "",
+            "METADATA_THUMBNAIL": "",
             "FP8": True,  # Default FP8 setting (--fp8_base)
             "SCALED": True,  # Default Scaled setting (--fp8_scaled, recommended with fp8_base)
             "QUANT_4BIT": False,  # 4-bit NF4 base (low-VRAM); supersedes fp8 when on
@@ -5596,6 +5598,25 @@ class LoRATrainerGUI:
         ttk.Label(parent, text="Metadata Tags:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=2)
         self.entries["METADATA_TAGS"] = ttk.Entry(parent, width=40)
         self.entries["METADATA_TAGS"].grid(row=row, column=1, sticky=tk.EW, padx=5, pady=2)
+        row += 1
+
+        ttk.Label(parent, text="Metadata Trigger Phrase:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=2)
+        self.entries["METADATA_TRIGGER_PHRASE"] = ttk.Entry(parent, width=40)
+        self.entries["METADATA_TRIGGER_PHRASE"].grid(row=row, column=1, sticky=tk.EW, padx=5, pady=2)
+        row += 1
+        ttk.Label(parent, text="Blank uses the Captions tab's trigger word.",
+                  foreground="#95A5A6", font=(FONT_FAMILY, 8, "italic")).grid(
+            row=row, column=0, columnspan=3, sticky=tk.W, padx=5)
+        row += 1
+
+        ttk.Label(parent, text="Metadata Thumbnail:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=2)
+        self.entries["METADATA_THUMBNAIL"] = ttk.Entry(parent, width=40)
+        self.entries["METADATA_THUMBNAIL"].grid(row=row, column=1, sticky=tk.EW, padx=5, pady=2)
+        ttk.Button(parent, text="Browse", command=lambda: self.browse_file("METADATA_THUMBNAIL", "file")).grid(row=row, column=2, sticky=tk.W, padx=5)
+        row += 1
+        ttk.Label(parent, text="Blank auto-embeds the latest sample preview; type 'off' to disable.",
+                  foreground="#95A5A6", font=(FONT_FAMILY, 8, "italic")).grid(
+            row=row, column=0, columnspan=3, sticky=tk.W, padx=5)
         row += 1
 
         return row
@@ -19104,6 +19125,8 @@ class LoRATrainerGUI:
             "METADATA_DESCRIPTION": self.entries["METADATA_DESCRIPTION"].get(),
             "METADATA_LICENSE": self.entries["METADATA_LICENSE"].get(),
             "METADATA_TAGS": self.entries["METADATA_TAGS"].get(),
+            "METADATA_TRIGGER_PHRASE": self.entries["METADATA_TRIGGER_PHRASE"].get(),
+            "METADATA_THUMBNAIL": self.entries["METADATA_THUMBNAIL"].get(),
             "FP8": self.fp8_var.get(),
             "SCALED": self.scaled_var.get(),
             "QUANT_4BIT": self.quant_4bit_var.get(),
@@ -19502,6 +19525,15 @@ class LoRATrainerGUI:
         if metadata_tags:
             command.extend(["--metadata_tags", metadata_tags])
 
+        metadata_trigger_phrase = self.settings["METADATA_TRIGGER_PHRASE"].strip() or \
+            (self.caption_trigger_var.get().strip() if hasattr(self, "caption_trigger_var") else "")
+        if metadata_trigger_phrase and metadata_trigger_phrase.lower() != "trigger_word":
+            command.extend(["--metadata_trigger_phrase", metadata_trigger_phrase])
+
+        metadata_thumbnail = self.settings["METADATA_THUMBNAIL"].strip()
+        if metadata_thumbnail:
+            command.extend(["--metadata_thumbnail", metadata_thumbnail])
+
         if self.settings["RESUME_TRAINING"].strip():
             command.append(f"--resume={self.settings['RESUME_TRAINING']}")
 
@@ -19789,6 +19821,15 @@ class LoRATrainerGUI:
             _mval = str(self.settings.get(_mkey, "") or "").strip()
             if _mval:
                 cmd += [_mflag, _mval]
+        # Trigger phrase falls back to the Captions tab's trigger word — independent of
+        # --trigger_word above, which is only ever sent when auto-recaption is on.
+        _mtrig = self.settings.get("METADATA_TRIGGER_PHRASE", "").strip() or \
+            (self.caption_trigger_var.get().strip() if hasattr(self, "caption_trigger_var") else "")
+        if _mtrig and _mtrig.lower() != "trigger_word":
+            cmd += ["--metadata_trigger_phrase", _mtrig]
+        _mthumb = self.settings.get("METADATA_THUMBNAIL", "").strip()
+        if _mthumb:
+            cmd += ["--metadata_thumbnail", _mthumb]
         # Base weight optimization. 4-bit NF4 supersedes fp8 (mutually exclusive): it quantizes the
         # frozen base to ~5.6 GB so a full LoRA trains on a 10-12 GB card with NO block swap (the
         # trainer forces blocks_to_swap=0 under 4-bit). Otherwise fp8 Base (the default) unless the

--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -1195,6 +1195,10 @@ class LoRATrainerGUI:
         self.extract_tab.bind("<Button-1>", self.remove_focus)
         self.notebook.add(self.extract_tab, text="Extract")
 
+        self.metadata_tab = ttk.Frame(self.notebook)
+        self.metadata_tab.bind("<Button-1>", self.remove_focus)
+        self.notebook.add(self.metadata_tab, text="Metadata")
+
         self.prefs_tab = ttk.Frame(self.notebook)
         self.prefs_tab.bind("<Button-1>", self.remove_focus)
         self.notebook.add(self.prefs_tab, text="Preferences")
@@ -1213,6 +1217,7 @@ class LoRATrainerGUI:
         self.create_explorer_tab()
         self.create_lora_royale_tab()
         self.create_extract_tab()
+        self.create_metadata_tab()
         self.create_prefs_tab()
         # Restore remembered Repair Studio / Explorer Setup fields + attach save traces.
         # After ALL tabs exist: restoring fires their traces, which touch other tabs' widgets.
@@ -2158,6 +2163,32 @@ class LoRATrainerGUI:
             selectbackground=[("readonly", COLORS["bg_surface"]), ("!disabled", COLORS["bg_surface"])],
             selectforeground=[("readonly", COLORS["text_primary"]), ("!disabled", COLORS["text_primary"])],
             bordercolor=[("focus", COLORS["border_focus"])]
+        )
+
+        # Treeview (the Metadata tab's custom-fields table). Nothing styled this before it —
+        # "clam" falls back to a stock white row background with no matching foreground, so
+        # rows rendered as near-invisible light-grey-on-white against an otherwise dark app.
+        style.configure(
+            "Treeview",
+            background=COLORS["bg_surface"],
+            fieldbackground=COLORS["bg_surface"],
+            foreground=COLORS["text_primary"],
+            bordercolor=COLORS["border"],
+            font=(FONT_FAMILY, 10),
+            rowheight=24,
+        )
+        style.map("Treeview",
+            background=[("selected", COLORS["accent"])],
+            foreground=[("selected", "white")]
+        )
+        style.configure(
+            "Treeview.Heading",
+            background=COLORS["bg_header"],
+            foreground=COLORS["text_primary"],
+            font=(FONT_FAMILY, 10, "bold"),
+        )
+        style.map("Treeview.Heading",
+            background=[("active", COLORS["bg_hover"])]
         )
 
         # Scrollbar. `background` is the thumb — the part you drag — and it used to be bg_header
@@ -12480,6 +12511,344 @@ class LoRATrainerGUI:
                 self.extract_progress_var.set("Error")
                 self.extract_run_btn.configure(state="normal")
             self.master.after(0, _show_error)
+
+    # endregion
+
+    # region Metadata Tab
+
+    def create_metadata_tab(self):
+        """Create the Metadata tab — view and edit the modelspec metadata on any .safetensors
+        file: LoRAs, DiTs, text encoders, embeddings, whatever — including ones Fizgig didn't
+        train, or trained before these fields existed."""
+        scrollable_frame, _ = self.create_scrollable_frame(self.metadata_tab)
+
+        outer = tk.Frame(scrollable_frame, bg=COLORS["bg_deep"])
+        outer.pack(fill=tk.BOTH, expand=True)
+
+        self._add_tab_banner(
+            outer,
+            "Metadata",
+            "View and edit the SAI ModelSpec metadata embedded in a .safetensors file — title, "
+            "author, description, trigger phrase, thumbnail, and anything else ComfyUI's model "
+            "browser reads. Works on any .safetensors file — LoRA, DiT, text encoder, "
+            "embedding — not just ones Fizgig trained.",
+        )
+
+        self._metadata_editor_path = None
+        self._metadata_editor_thumbnail_uri = None  # current thumbnail data URI, or None
+        self._metadata_editor_custom = {}  # every key outside the standard fields below
+        self._metadata_thumb_photo = None  # keeps the PhotoImage alive; Tk drops it otherwise
+
+        # --- Load ---
+        load_card = self._start_section_card(
+            outer, "File",
+            "Pick any .safetensors file — LoRA, DiT, text encoder, embedding — its current "
+            "metadata loads below.",
+        )
+        load_card.grid_columnconfigure(1, weight=1)
+        ttk.Label(load_card, text="File:").grid(row=0, column=0, sticky=tk.W, padx=(0, 10), pady=4)
+        self.metadata_file_var = tk.StringVar()
+        ttk.Entry(load_card, textvariable=self.metadata_file_var, width=60).grid(
+            row=0, column=1, sticky=tk.EW, pady=4)
+        ttk.Button(load_card, text="Browse", command=self._browse_metadata_file).grid(
+            row=0, column=2, sticky=tk.W, padx=(8, 0), pady=4)
+        self._metadata_status_label = tk.Label(
+            load_card, text="No file loaded.", font=(FONT_FAMILY, 9, "italic"),
+            fg=COLORS["text_muted"], bg=COLORS["bg_surface"])
+        self._metadata_status_label.grid(row=1, column=1, sticky=tk.W, pady=(2, 0))
+
+        # --- Standard fields ---
+        fields_card = self._start_section_card(
+            outer, "Standard Fields",
+            "The fields ComfyUI's model browser (and other spec-aware tools) render specially.",
+        )
+        fields_card.grid_columnconfigure(1, weight=1)
+
+        def _field_row(label_text, row):
+            ttk.Label(fields_card, text=label_text).grid(
+                row=row, column=0, sticky=tk.NW, padx=(0, 10), pady=4)
+            var = tk.StringVar()
+            ttk.Entry(fields_card, textvariable=var, width=60).grid(
+                row=row, column=1, sticky=tk.EW, pady=4)
+            return var
+
+        self.metadata_title_var = _field_row("Title:", 0)
+        self.metadata_author_var = _field_row("Author:", 1)
+        self.metadata_license_var = _field_row("License:", 2)
+        self.metadata_tags_var = _field_row("Tags:", 3)
+        self.metadata_trigger_var = _field_row("Trigger Phrase:", 4)
+        self.metadata_usage_hint_var = _field_row("Usage Hint:", 5)
+
+        ttk.Label(fields_card, text="Description:").grid(
+            row=6, column=0, sticky=tk.NW, padx=(0, 10), pady=4)
+        self.metadata_description_text = tk.Text(
+            fields_card, width=60, height=5, wrap=tk.WORD,
+            bg=COLORS["bg_surface"], fg=COLORS["text_primary"],
+            insertbackground=COLORS["text_primary"], font=(FONT_FAMILY, 10),
+            relief="flat", highlightthickness=1,
+            highlightbackground=COLORS["border"], highlightcolor=COLORS["border_focus"],
+        )
+        self.metadata_description_text.grid(row=6, column=1, sticky=tk.EW, pady=4)
+
+        # --- Thumbnail ---
+        thumb_card = self._start_section_card(
+            outer, "Thumbnail",
+            "The image ComfyUI shows as card art. Fizgig auto-embeds the latest training sample "
+            "when it trains a LoRA — replace or clear it here for any file.",
+        )
+        self._metadata_thumb_label = tk.Label(thumb_card, bg=COLORS["bg_surface"],
+                                              text="(no thumbnail)", fg=COLORS["text_muted"])
+        self._metadata_thumb_label.pack(anchor=tk.W, pady=(0, 8))
+        thumb_btn_row = tk.Frame(thumb_card, bg=COLORS["bg_surface"])
+        thumb_btn_row.pack(anchor=tk.W)
+        ttk.Button(thumb_btn_row, text="Replace...",
+                   command=self._browse_metadata_thumbnail).pack(side=tk.LEFT, padx=(0, 8))
+        ttk.Button(thumb_btn_row, text="Clear",
+                   command=self._clear_metadata_thumbnail).pack(side=tk.LEFT)
+
+        # --- Custom fields ---
+        custom_card = self._start_section_card(
+            outer, "Custom Fields",
+            "Like ID3 tags on an MP3 — the format isn't limited to a fixed list, and a reader "
+            "just ignores whatever it doesn't recognize. Add anything you want: author_email, "
+            "a colorspace profile note, whatever's useful to you. Not part of the SAI ModelSpec "
+            "standard, so tools other than Fizgig won't render these specially, but they're "
+            "stored in the file like any other metadata. Also shows any non-standard keys "
+            "already in the file — nothing gets silently dropped on save.",
+        )
+        tree_frame = tk.Frame(custom_card, bg=COLORS["bg_surface"])
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+        self.metadata_custom_tree = ttk.Treeview(
+            tree_frame, columns=("key", "value"), show="headings", height=6)
+        self.metadata_custom_tree.heading("key", text="Key")
+        self.metadata_custom_tree.heading("value", text="Value")
+        self.metadata_custom_tree.column("key", width=220, anchor=tk.W)
+        self.metadata_custom_tree.column("value", width=420, anchor=tk.W)
+        self.metadata_custom_tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        tree_scroll = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL,
+                                    command=self.metadata_custom_tree.yview)
+        tree_scroll.pack(side=tk.LEFT, fill=tk.Y)
+        self.metadata_custom_tree.configure(yscrollcommand=tree_scroll.set)
+
+        custom_btn_row = tk.Frame(custom_card, bg=COLORS["bg_surface"])
+        custom_btn_row.pack(anchor=tk.W, pady=(8, 0))
+        ttk.Button(custom_btn_row, text="Add field...",
+                   command=self._add_metadata_custom_field).pack(side=tk.LEFT, padx=(0, 8))
+        ttk.Button(custom_btn_row, text="Remove selected",
+                   command=self._remove_metadata_custom_field).pack(side=tk.LEFT)
+
+        # --- Save ---
+        save_row = tk.Frame(outer, bg=COLORS["bg_deep"])
+        save_row.pack(fill=tk.X, padx=36, pady=(0, 20))
+        ttk.Button(save_row, text="Save",
+                   command=lambda: self._save_metadata_file(save_as=False)).pack(
+            side=tk.LEFT, padx=(0, 8))
+        ttk.Button(save_row, text="Save As...",
+                   command=lambda: self._save_metadata_file(save_as=True)).pack(side=tk.LEFT)
+        self._metadata_save_status = tk.Label(
+            save_row, text="", font=(FONT_FAMILY, 9, "italic"),
+            fg=COLORS["text_muted"], bg=COLORS["bg_deep"])
+        self._metadata_save_status.pack(side=tk.LEFT, padx=(16, 0))
+
+    def _browse_metadata_file(self):
+        filepath = filedialog.askopenfilename(
+            title="Select a .safetensors file",
+            filetypes=[("SafeTensors", "*.safetensors"), ("All files", "*.*")],
+            initialdir=self._lora_initialdir(),
+        )
+        if filepath:
+            self.metadata_file_var.set(filepath)
+            self._load_metadata_file(filepath)
+
+    def _load_metadata_file(self, path):
+        from fizgig.training.metadata import load_metadata_from_safetensors
+        try:
+            meta = load_metadata_from_safetensors(path)
+        except Exception as e:
+            messagebox.showerror("Error", f"Could not read metadata:\n{e}")
+            return
+
+        self._metadata_editor_path = path
+        standard = {
+            "modelspec.title": self.metadata_title_var,
+            "modelspec.author": self.metadata_author_var,
+            "modelspec.license": self.metadata_license_var,
+            "modelspec.tags": self.metadata_tags_var,
+            "modelspec.trigger_phrase": self.metadata_trigger_var,
+            "modelspec.usage_hint": self.metadata_usage_hint_var,
+        }
+        for key, var in standard.items():
+            var.set(meta.get(key, "") or "")
+
+        self.metadata_description_text.delete("1.0", tk.END)
+        self.metadata_description_text.insert("1.0", meta.get("modelspec.description", "") or "")
+
+        self._metadata_editor_thumbnail_uri = meta.get("modelspec.thumbnail")
+        self._show_metadata_thumbnail_preview(self._metadata_editor_thumbnail_uri)
+
+        skip_keys = set(standard.keys()) | {"modelspec.description", "modelspec.thumbnail"}
+        self._metadata_editor_custom = {k: v for k, v in meta.items() if k not in skip_keys}
+        self._refresh_metadata_custom_tree()
+
+        n = len(meta)
+        self._metadata_status_label.config(
+            text=f"Loaded — {n} metadata key{'s' if n != 1 else ''} found.",
+            fg=COLORS["text_secondary"])
+        self._metadata_save_status.config(text="")
+
+    def _show_metadata_thumbnail_preview(self, data_uri):
+        if not data_uri or not str(data_uri).startswith("data:image"):
+            self._metadata_thumb_label.config(image="", text="(no thumbnail)")
+            self._metadata_thumb_photo = None
+            return
+        try:
+            import base64
+            from io import BytesIO
+            b64 = data_uri.split(",", 1)[1]
+            img = Image.open(BytesIO(base64.b64decode(b64)))
+            img.thumbnail((256, 256))
+            photo = ImageTk.PhotoImage(img)
+            self._metadata_thumb_photo = photo  # reference kept alive deliberately
+            self._metadata_thumb_label.config(image=photo, text="")
+        except Exception:
+            self._metadata_thumb_label.config(image="", text="(couldn't decode thumbnail)")
+            self._metadata_thumb_photo = None
+
+    def _browse_metadata_thumbnail(self):
+        filepath = filedialog.askopenfilename(
+            title="Select a thumbnail image",
+            filetypes=[("Images", "*.png *.jpg *.jpeg *.webp"), ("All files", "*.*")],
+        )
+        if not filepath:
+            return
+        from fizgig.training.metadata import thumbnail_data_uri
+        uri = thumbnail_data_uri(filepath)
+        if not uri:
+            messagebox.showerror("Error", "Could not read that image.")
+            return
+        self._metadata_editor_thumbnail_uri = uri
+        self._show_metadata_thumbnail_preview(uri)
+
+    def _clear_metadata_thumbnail(self):
+        self._metadata_editor_thumbnail_uri = None
+        self._show_metadata_thumbnail_preview(None)
+
+    def _refresh_metadata_custom_tree(self):
+        self.metadata_custom_tree.delete(*self.metadata_custom_tree.get_children())
+        for k, v in sorted(self._metadata_editor_custom.items()):
+            display_v = v if len(str(v)) <= 120 else str(v)[:117] + "..."
+            self.metadata_custom_tree.insert("", tk.END, iid=k, values=(k, display_v))
+
+    def _add_metadata_custom_field(self):
+        dlg = tk.Toplevel(self.master)
+        dlg.title("Add custom field")
+        dlg.configure(bg=BG_COLOR)
+        dlg.transient(self.master)
+        tk.Label(dlg, text="Key:", bg=BG_COLOR, fg=COLORS["text_secondary"]).grid(
+            row=0, column=0, sticky=tk.W, padx=10, pady=(10, 2))
+        key_entry = ttk.Entry(dlg, width=40)
+        key_entry.grid(row=0, column=1, padx=10, pady=(10, 2))
+        tk.Label(dlg, text="Value:", bg=BG_COLOR, fg=COLORS["text_secondary"]).grid(
+            row=1, column=0, sticky=tk.W, padx=10, pady=2)
+        val_entry = ttk.Entry(dlg, width=40)
+        val_entry.grid(row=1, column=1, padx=10, pady=2)
+
+        def ok():
+            k = key_entry.get().strip()
+            v = val_entry.get().strip()
+            if k:
+                self._metadata_editor_custom[k] = v
+                self._refresh_metadata_custom_tree()
+            dlg.destroy()
+
+        btn_row = tk.Frame(dlg, bg=BG_COLOR)
+        btn_row.grid(row=2, column=0, columnspan=2, pady=10)
+        ttk.Button(btn_row, text="Cancel", command=dlg.destroy).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_row, text="Add", command=ok).pack(side=tk.LEFT, padx=5)
+        key_entry.bind("<Return>", lambda e: ok())
+        key_entry.focus_set()
+        dlg.grab_set()
+
+    def _remove_metadata_custom_field(self):
+        for k in self.metadata_custom_tree.selection():
+            self._metadata_editor_custom.pop(k, None)
+        self._refresh_metadata_custom_tree()
+
+    def _save_metadata_file(self, save_as=False):
+        if not self._metadata_editor_path:
+            messagebox.showinfo("No file loaded", "Load a .safetensors file first.")
+            return
+
+        dest = self._metadata_editor_path
+        if save_as:
+            dest = filedialog.asksaveasfilename(
+                title="Save file as",
+                defaultextension=".safetensors",
+                filetypes=[("SafeTensors", "*.safetensors")],
+                initialfile=os.path.basename(self._metadata_editor_path),
+            )
+            if not dest:
+                return
+        elif not messagebox.askyesno(
+                "Overwrite?",
+                f"Save metadata changes to:\n{dest}\n\nThis overwrites the file in place."):
+            return
+
+        try:
+            from safetensors.torch import load_file, save_file
+            # .clone() forces a real copy out of the mmap'd view load_file returns. Without
+            # this, saving back onto the SAME path fails on Windows with "the requested
+            # operation cannot be performed on a file with a user-mapped section open"
+            # (error 1224) — the mapping from this exact load is still active, and Windows
+            # (unlike Linux) refuses to overwrite a file while it's mapped. Cloning breaks
+            # that dependency before we ever try to write.
+            tensors = {k: v.clone() for k, v in load_file(self._metadata_editor_path).items()}
+        except Exception as e:
+            messagebox.showerror("Error", f"Could not read the file's tensors:\n{e}")
+            return
+
+        new_meta = dict(self._metadata_editor_custom)
+        field_map = {
+            "modelspec.title": self.metadata_title_var.get().strip(),
+            "modelspec.author": self.metadata_author_var.get().strip(),
+            "modelspec.license": self.metadata_license_var.get().strip(),
+            "modelspec.tags": self.metadata_tags_var.get().strip(),
+            "modelspec.trigger_phrase": self.metadata_trigger_var.get().strip(),
+            "modelspec.usage_hint": self.metadata_usage_hint_var.get().strip(),
+            "modelspec.description": self.metadata_description_text.get("1.0", "end-1c").strip(),
+        }
+        for k, v in field_map.items():
+            if v:
+                new_meta[k] = v
+        if self._metadata_editor_thumbnail_uri:
+            new_meta["modelspec.thumbnail"] = self._metadata_editor_thumbnail_uri
+
+        # A metadata-only edit still goes through a full resave, which isn't guaranteed to be
+        # byte-identical to the original — so hashes computed over the old bytes can no longer
+        # be trusted. Same move bake.py already makes whenever it changes a file's contents.
+        for stale in ("sshs_model_hash", "sshs_legacy_hash", "modelspec.hash_sha256"):
+            new_meta.pop(stale, None)
+
+        # Write to a temp file and swap it in atomically, so a failed/interrupted save can
+        # never leave the original file half-written.
+        tmp_dest = dest + ".tmp"
+        try:
+            save_file(tensors, tmp_dest, metadata=new_meta)
+            os.replace(tmp_dest, dest)
+        except Exception as e:
+            try:
+                if os.path.exists(tmp_dest):
+                    os.remove(tmp_dest)
+            except OSError:
+                pass
+            messagebox.showerror("Error", f"Could not save:\n{e}")
+            return
+
+        self._metadata_save_status.config(text=f"Saved {os.path.basename(dest)}",
+                                          fg=COLORS["text_secondary"])
+        if save_as:
+            self.metadata_file_var.set(dest)
+            self._metadata_editor_path = dest
 
     # endregion
 

--- a/src/fizgig/krea2/trainer.py
+++ b/src/fizgig/krea2/trainer.py
@@ -34,7 +34,7 @@ from fizgig.krea2.sampling import gather_valid_text, prepare
 from fizgig.modules.sdpa import consider_training_backend as _consider_training_backend
 from fizgig.networks.lora import create_network
 from fizgig.training.metadata import (
-    ARCHITECTURE_KREA2, build_metadata, latest_sample_image, thumbnail_data_uri,
+    ARCHITECTURE_KREA2, build_metadata, latest_sample_image, thumbnail_data_uri, resolve_title,
 )
 from fizgig.training.train_utils import LossRecorder, prune_state_dirs
 
@@ -1089,7 +1089,7 @@ def sample_previews(turbo_path, ae, encoded_prompts, lora_sd, out_dir, epoch, *,
                     output_name="krea2", steps=8, cfg_scale=1.0, neg=None,
                     width=512, height=512,
                     seed=42, context_lora_path=None, context_lora_strength=1.0,
-                    blocks_to_swap=0, int8=False, device="cuda"):
+                    blocks_to_swap=0, int8=False, device="cuda", prompts=None):
     """Load the (clean) pre-quant fp8 Turbo, apply the current LoRA LIVE (no merge -> no grid),
     and render each pre-encoded prompt. Turbo is freed afterwards.
 
@@ -1137,23 +1137,31 @@ def sample_previews(turbo_path, ae, encoded_prompts, lora_sd, out_dir, epoch, *,
         turbo.move_to_device_except_swap_blocks(torch.device(device))
         turbo.switch_block_swap_for_inference()
     turbo.eval()
-    paths = _render_prompt_set(turbo, ae, encoded_prompts, out_dir, epoch,
-                               output_name=output_name, steps=steps, cfg_scale=cfg_scale,
-                               neg=neg, width=width, height=height, seed=seed, device=device)
+    result = _render_prompt_set(turbo, ae, encoded_prompts, out_dir, epoch,
+                                output_name=output_name, steps=steps, cfg_scale=cfg_scale,
+                                neg=neg, width=width, height=height, seed=seed, device=device,
+                                prompts=prompts)
     del turbo, net, ctx_net
     torch.cuda.empty_cache()
-    return paths
+    return result
 
 
 def _render_prompt_set(model, ae, encoded_prompts, out_dir, epoch, *, output_name, steps,
-                       cfg_scale, neg, width, height, seed, device):
+                       cfg_scale, neg, width, height, seed, device, prompts=None):
     """Shared preview render loop — identical settings (mu=1.15 pinned) and the exact gallery
-    filename pattern for both the Turbo-model path and the turbo-LoRA-on-training-DiT path."""
+    filename pattern for both the Turbo-model path and the turbo-LoRA-on-training-DiT path.
+
+    `prompts` is the raw text parallel to `encoded_prompts` (same order, same length) — optional
+    because a couple of call sites don't have it handy, but when it's there we hand back which
+    prompt made the LAST image, so a checkpoint saved right after can default its description to
+    it instead of shipping blank (same idea as the auto-thumbnail, which is already whatever
+    sample happens to be newest on disk)."""
     import datetime
     from fizgig.krea2 import sampling
     os.makedirs(out_dir, exist_ok=True)
     ts = datetime.datetime.now().strftime("%Y%m%d%H%M%S")  # 14-digit timestamp
     paths = []
+    last_prompt = None
     # Negative prompt rides through the CFG path (untxt) — only when CFG is actually on.
     _untxt = _untxtmask = None
     if neg is not None and cfg_scale and cfg_scale > 1.0:
@@ -1166,12 +1174,15 @@ def _render_prompt_set(model, ae, encoded_prompts, out_dir, epoch, *, output_nam
         p = os.path.join(out_dir, f"{output_name}_e{epoch:06d}_{i:02d}_{ts}_{seed + i}.png")
         imgs[0].save(p)
         paths.append(p)
-    return paths
+        if prompts and i < len(prompts):
+            last_prompt = prompts[i]
+    return paths, last_prompt
 
 
 def sample_previews_on_dit(dit, turbo_net, turbo_diffb, ae, encoded_prompts, out_dir, epoch, *,
                            output_name="krea2", steps=8, cfg_scale=1.0, neg=None,
-                           width=512, height=512, seed=42, blocks_to_swap=0, device="cuda"):
+                           width=512, height=512, seed=42, blocks_to_swap=0, device="cuda",
+                           prompts=None):
     """Render previews on the RESIDENT training DiT with the Turbo LoRA enabled at 1.0 —
     no Turbo checkpoint load, no parking the trainer to CPU.
 
@@ -1200,7 +1211,8 @@ def sample_previews_on_dit(dit, turbo_net, turbo_diffb, ae, encoded_prompts, out
             bias.data.add_(delta.to(device=bias.device, dtype=bias.dtype))
         return _render_prompt_set(dit, ae, encoded_prompts, out_dir, epoch,
                                   output_name=output_name, steps=steps, cfg_scale=cfg_scale,
-                                  neg=neg, width=width, height=height, seed=seed, device=device)
+                                  neg=neg, width=width, height=height, seed=seed, device=device,
+                                  prompts=prompts)
     finally:
         for bias, snap in saved_biases:
             bias.data.copy_(snap)
@@ -1300,6 +1312,11 @@ def train_krea2(
     GUI wiring are layered on elsewhere."""
     torch.manual_seed(seed)
 
+    # Updated at every sample render (see the sample_previews*/prompts= call sites below) so
+    # _sai_metadata can default the description to whatever prompt made the newest thumbnail,
+    # instead of shipping blank.
+    _last_sample_prompt = None
+
     def _sai_metadata():
         """SAI ModelSpec block shared by every checkpoint (per-epoch and final), so an epoch
         picked over the last one is just as identifiable in ComfyUI. Thumbnail defaults to
@@ -1312,8 +1329,11 @@ def train_krea2(
             thumb_source = latest_sample_image(output_dir)
         return build_metadata(
             None, ARCHITECTURE_KREA2, time.time(),
-            title=metadata_title if metadata_title is not None else output_name,
-            author=metadata_author, description=metadata_description,
+            title=(metadata_title if metadata_title is not None
+                   else resolve_title(output_name, metadata_trigger_phrase)),
+            author=metadata_author,
+            description=(metadata_description if metadata_description is not None
+                         else _last_sample_prompt),
             license=metadata_license, tags=metadata_tags,
             trigger_phrase=metadata_trigger_phrase,
             thumbnail=thumbnail_data_uri(thumb_source),
@@ -1702,11 +1722,13 @@ def train_krea2(
         logger.info("rendering epoch-0 preview (Sample at Start, on training DiT)...")
         try:
             _seed0 = sample_seed if sample_seed != 0 else random.randint(1, 2**31 - 1)
-            sample_previews_on_dit(dit, turbo_net, turbo_diffb, sample_ae, encoded_prompts,
+            _, _last_p = sample_previews_on_dit(dit, turbo_net, turbo_diffb, sample_ae, encoded_prompts,
                                    sample_dir, 0, output_name=output_name, steps=sample_steps,
                                    cfg_scale=sample_cfg_scale, neg=encoded_negative,
                                    width=sample_width, height=sample_height, seed=_seed0,
-                                   blocks_to_swap=blocks_to_swap, device=device)
+                                   blocks_to_swap=blocks_to_swap, device=device, prompts=sample_prompts)
+            if _last_p:
+                _last_sample_prompt = _last_p
         except Exception as _e0:
             logger.warning(f"[preview] Sample at Start failed ({type(_e0).__name__}) — training "
                            f"continues; per-epoch previews will still be attempted.")
@@ -1723,13 +1745,16 @@ def train_krea2(
         torch.cuda.empty_cache()
         try:
             _seed0 = sample_seed if sample_seed != 0 else random.randint(1, 2**31 - 1)
-            sample_previews(turbo_path, sample_ae, encoded_prompts, _lf0(_tmp0), sample_dir, 0,
+            _, _last_p = sample_previews(turbo_path, sample_ae, encoded_prompts, _lf0(_tmp0), sample_dir, 0,
                             output_name=output_name, steps=sample_steps,
                             cfg_scale=sample_cfg_scale, neg=encoded_negative,
                             width=sample_width, height=sample_height, seed=_seed0,
                             context_lora_path=context_lora_path,
                             context_lora_strength=context_lora_strength,
-                            blocks_to_swap=preview_blocks_to_swap, int8=preview_int8, device=device)
+                            blocks_to_swap=preview_blocks_to_swap, int8=preview_int8, device=device,
+                            prompts=sample_prompts)
+            if _last_p:
+                _last_sample_prompt = _last_p
         except Exception as _e0:
             logger.warning(f"[preview] Sample at Start failed ({type(_e0).__name__}) — training "
                            f"continues; per-epoch previews will still be attempted.")
@@ -1902,16 +1927,21 @@ def train_krea2(
                     prev_enc = encode_sample_prompts(te_path, [ov["prompt"]],
                                                      ref_image=ov.get("ref_image") or None, device=device)
                     prev_w, prev_h, prev_seed = ov["width"], ov["height"], ov["seed"]
+                    prev_prompts = [ov["prompt"]]
                 else:
                     prev_enc, prev_w, prev_h, prev_seed = encoded_prompts, sample_width, sample_height, sample_seed
+                    prev_prompts = sample_prompts
                 if prev_seed == 0:
                     prev_seed = random.randint(1, 2**31 - 1)
                     logger.info(f"[sample] seed 0 -> random {prev_seed}")
-                sample_previews_on_dit(dit, turbo_net, turbo_diffb, sample_ae, prev_enc,
+                _, _last_p = sample_previews_on_dit(dit, turbo_net, turbo_diffb, sample_ae, prev_enc,
                                        sample_dir, epoch + 1, output_name=output_name,
                                        steps=sample_steps, cfg_scale=sample_cfg_scale,
                                        neg=encoded_negative, width=prev_w, height=prev_h,
-                                       seed=prev_seed, blocks_to_swap=blocks_to_swap, device=device)
+                                       seed=prev_seed, blocks_to_swap=blocks_to_swap, device=device,
+                                       prompts=prev_prompts)
+                if _last_p:
+                    _last_sample_prompt = _last_p
             except Exception as _prev_err:
                 _oom = "out of memory" in str(_prev_err).lower()
                 logger.warning(
@@ -1951,19 +1981,24 @@ def train_krea2(
                     prev_enc = encode_sample_prompts(te_path, [ov["prompt"]],
                                                      ref_image=ov.get("ref_image") or None, device=device)
                     prev_w, prev_h, prev_seed = ov["width"], ov["height"], ov["seed"]
+                    prev_prompts = [ov["prompt"]]
                 else:
                     prev_enc, prev_w, prev_h, prev_seed = encoded_prompts, sample_width, sample_height, sample_seed
+                    prev_prompts = sample_prompts
                 # Seed 0 means "random": pick a fresh seed for this preview so 0 isn't a fixed seed
                 # (each epoch's sample differs). Covers the Samples-tab field and a 0 in the override.
                 if prev_seed == 0:
                     prev_seed = random.randint(1, 2**31 - 1)
                     logger.info(f"[sample] seed 0 -> random {prev_seed}")
-                sample_previews(turbo_path, sample_ae, prev_enc, load_file(tmp), sample_dir, epoch + 1,
+                _, _last_p = sample_previews(turbo_path, sample_ae, prev_enc, load_file(tmp), sample_dir, epoch + 1,
                                 output_name=output_name, steps=sample_steps,
                                 cfg_scale=sample_cfg_scale, neg=encoded_negative, width=prev_w,
                                 height=prev_h, seed=prev_seed,
                                 context_lora_path=context_lora_path, context_lora_strength=context_lora_strength,
-                                blocks_to_swap=preview_blocks_to_swap, int8=preview_int8, device=device)
+                                blocks_to_swap=preview_blocks_to_swap, int8=preview_int8, device=device,
+                                prompts=prev_prompts)
+                if _last_p:
+                    _last_sample_prompt = _last_p
             except Exception as _prev_err:
                 # A preview failure — almost always CUDA OOM (the ~13 GB Turbo + the Qwen3-VL
                 # encoder won't fit alongside the parked training DiT on a small card) — must NEVER

--- a/src/fizgig/krea2/trainer.py
+++ b/src/fizgig/krea2/trainer.py
@@ -33,7 +33,9 @@ from fizgig.krea2.utils import load_krea2_dit
 from fizgig.krea2.sampling import gather_valid_text, prepare
 from fizgig.modules.sdpa import consider_training_backend as _consider_training_backend
 from fizgig.networks.lora import create_network
-from fizgig.training.metadata import ARCHITECTURE_KREA2
+from fizgig.training.metadata import (
+    ARCHITECTURE_KREA2, build_metadata, latest_sample_image, thumbnail_data_uri,
+)
 from fizgig.training.train_utils import LossRecorder, prune_state_dirs
 
 logger = logging.getLogger(__name__)
@@ -1288,6 +1290,8 @@ def train_krea2(
     metadata_description: str = None,
     metadata_license: str = None,
     metadata_tags: str = None,
+    metadata_trigger_phrase: str = None,
+    metadata_thumbnail: str = None,
     device: str = "cuda",
     dtype: torch.dtype = torch.bfloat16,
 ):
@@ -1295,6 +1299,25 @@ def train_krea2(
     flow-matching loss -> AdamW -> save a ComfyUI-compatible LoRA. In-training Turbo previews +
     GUI wiring are layered on elsewhere."""
     torch.manual_seed(seed)
+
+    def _sai_metadata():
+        """SAI ModelSpec block shared by every checkpoint (per-epoch and final), so an epoch
+        picked over the last one is just as identifiable in ComfyUI. Thumbnail defaults to
+        whatever preview training has produced so far — cosmetic, so a missing one is fine."""
+        if metadata_thumbnail and metadata_thumbnail.lower() in ("off", "none"):
+            thumb_source = None
+        elif metadata_thumbnail:
+            thumb_source = metadata_thumbnail
+        else:
+            thumb_source = latest_sample_image(output_dir)
+        return build_metadata(
+            None, ARCHITECTURE_KREA2, time.time(),
+            title=metadata_title if metadata_title is not None else output_name,
+            author=metadata_author, description=metadata_description,
+            license=metadata_license, tags=metadata_tags,
+            trigger_phrase=metadata_trigger_phrase,
+            thumbnail=thumbnail_data_uri(thumb_source),
+        )
 
     shared_epoch = Value("i", 0)
     user_config = load_user_config(dataset_config)
@@ -1850,7 +1873,8 @@ def train_krea2(
             # comfy_format so a user's picked-best epoch is byte-format-identical to the final
             # artifact (LoKR: LyCORIS-standard keys). No-op for standard LoRA.
             _save_lora(network, os.path.join(output_dir, f"{output_name}-{epoch + 1:06d}.safetensors"),
-                       network_dim, network_alpha, dtype, comfy_format=True)
+                       network_dim, network_alpha, dtype, extra_metadata=_sai_metadata(),
+                       comfy_format=True)
             # Resumable state rides the checkpoint cadence. Safe to snapshot here: pending_accum
             # was flushed above, the adaptive-LR watcher has already made its call for this epoch,
             # and any queued caption updates are applied — so the optimizer is settled.
@@ -2017,12 +2041,9 @@ def train_krea2(
     if context_lora_path:
         extra.update({"ss_context_lora": os.path.basename(context_lora_path),
                       "ss_context_lora_strength": str(context_lora_strength)})
-    # User metadata (GUI: Other Options → Metadata) — same keys ComfyUI/model managers read.
-    for _mk, _mv in (("modelspec.title", metadata_title), ("modelspec.author", metadata_author),
-                     ("modelspec.description", metadata_description),
-                     ("modelspec.license", metadata_license), ("modelspec.tags", metadata_tags)):
-        if _mv:
-            extra[_mk] = str(_mv)
+    # Full SAI ModelSpec block — same keys ComfyUI/model managers read (GUI: Other Options →
+    # Metadata), plus trigger phrase and an auto-picked sample thumbnail.
+    extra.update(_sai_metadata())
     _save_lora(network, out, network_dim, network_alpha, dtype, extra_metadata=extra,
                comfy_format=True)
     logger.info(f"saved final LoRA -> {out}")

--- a/src/fizgig/scripts/krea2_train.py
+++ b/src/fizgig/scripts/krea2_train.py
@@ -95,6 +95,12 @@ def setup_parser() -> argparse.ArgumentParser:
     p.add_argument("--metadata_description", default=None)
     p.add_argument("--metadata_license", default=None)
     p.add_argument("--metadata_tags", default=None)
+    p.add_argument("--metadata_trigger_phrase", default=None,
+                   help="Trigger word(s) recorded as modelspec.trigger_phrase. "
+                        "Defaults to --trigger_word when omitted.")
+    p.add_argument("--metadata_thumbnail", default=None,
+                   help="Path to an image to embed as modelspec.thumbnail. Omit to "
+                        "auto-use the latest sample preview; pass 'off' to disable.")
     p.add_argument("--preview_blocks_to_swap", type=int, default=0,
                    help="Forward-only block swap on the preview Turbo (fits smaller cards)")
     p.add_argument("--preview_int8", action="store_true",
@@ -179,6 +185,8 @@ def main():
         metadata_title=args.metadata_title, metadata_author=args.metadata_author,
         metadata_description=args.metadata_description,
         metadata_license=args.metadata_license, metadata_tags=args.metadata_tags,
+        metadata_trigger_phrase=args.metadata_trigger_phrase or args.trigger_word,
+        metadata_thumbnail=args.metadata_thumbnail,
         preview_blocks_to_swap=args.preview_blocks_to_swap,
         preview_int8=args.preview_int8,
         resume_state_dir=args.resume,

--- a/src/fizgig/training/metadata.py
+++ b/src/fizgig/training/metadata.py
@@ -47,7 +47,15 @@ BASE_METADATA = {
     "modelspec.encoder_layer": None,
     "modelspec.trigger_phrase": None,
     "modelspec.thumbnail": None,
+    "modelspec.usage_hint": None,
 }
+
+# The GUI's default, unedited value for the Output Name field (lora_trainer_gui.py's
+# LORA_NAME setting). _apply_lora_name_suffix there only ever swaps the trailing "_k9b"/
+# "_krea2" tag to match the selected family, so an untouched field is always exactly one of
+# these two — never anything else. Used to keep obvious placeholder text like
+# "LoraName_TokenName_krea2" out of modelspec.title.
+PLACEHOLDER_OUTPUT_NAMES = {"loraname_tokenname_k9b", "loraname_tokenname_krea2"}
 
 
 def load_bytes_in_safetensors(tensors):
@@ -85,10 +93,17 @@ def build_metadata(
     is_lora: bool = True,
     trigger_phrase: Optional[str] = None,
     thumbnail: Optional[str] = None,
+    usage_hint: Optional[str] = None,
 ) -> dict:
     """Build SAI model spec metadata for Klein 9B LoRA files."""
     metadata = {}
     metadata.update(BASE_METADATA)
+
+    # A reasonable default beats a blank field nobody's ever been able to set before now —
+    # same reasoning as the auto-thumbnail. Only kicks in when there's nothing to lose: an
+    # explicit usage_hint always wins, and this needs a trigger_phrase to say anything useful.
+    if usage_hint is None and trigger_phrase:
+        usage_hint = f"Include '{trigger_phrase}' in your prompt."
 
     # Map Fizgig architecture to SAI model spec
     if architecture in (ARCHITECTURE_KLEIN_9B, ARCHITECTURE_KLEIN_9B_FULL):
@@ -118,6 +133,7 @@ def build_metadata(
         ("modelspec.merged_from", merged_from),
         ("modelspec.trigger_phrase", trigger_phrase),
         ("modelspec.thumbnail", thumbnail),
+        ("modelspec.usage_hint", usage_hint),
     ]:
         if value is not None:
             metadata[key] = value
@@ -197,6 +213,18 @@ def thumbnail_data_uri(image_path: Optional[str], max_size: int = 512, quality: 
     except Exception:
         logger.warning(f"could not build metadata thumbnail from {image_path}", exc_info=True)
         return None
+
+
+def resolve_title(output_name: Optional[str], trigger_phrase: Optional[str]) -> Optional[str]:
+    """The output name, unless it's still the GUI's untouched placeholder — in which case
+    fall back to the trigger phrase (if there is one) rather than writing obvious filler like
+    "LoraName_TokenName_krea2" into modelspec.title. Deliberately narrow: this only ever
+    affects the metadata title, never the actual filename/output_name used everywhere else in
+    the run (cache dirs, state dirs, the checkpoint's own name), which stays exactly what the
+    user set regardless."""
+    if output_name and output_name.strip().lower() in PLACEHOLDER_OUTPUT_NAMES and trigger_phrase:
+        return trigger_phrase
+    return output_name
 
 
 def get_title(metadata: dict) -> Optional[str]:

--- a/src/fizgig/training/metadata.py
+++ b/src/fizgig/training/metadata.py
@@ -4,6 +4,7 @@ Based on https://github.com/Stability-AI/ModelSpec
 Klein 9B specific — other architectures stripped.
 """
 
+import base64
 import datetime
 import hashlib
 from io import BytesIO
@@ -44,6 +45,8 @@ BASE_METADATA = {
     "modelspec.prediction_type": None,
     "modelspec.timestep_range": None,
     "modelspec.encoder_layer": None,
+    "modelspec.trigger_phrase": None,
+    "modelspec.thumbnail": None,
 }
 
 
@@ -80,6 +83,8 @@ def build_metadata(
     merged_from: Optional[str] = None,
     timesteps: Optional[Tuple[int, int]] = None,
     is_lora: bool = True,
+    trigger_phrase: Optional[str] = None,
+    thumbnail: Optional[str] = None,
 ) -> dict:
     """Build SAI model spec metadata for Klein 9B LoRA files."""
     metadata = {}
@@ -111,6 +116,8 @@ def build_metadata(
         ("modelspec.license", license),
         ("modelspec.tags", tags),
         ("modelspec.merged_from", merged_from),
+        ("modelspec.trigger_phrase", trigger_phrase),
+        ("modelspec.thumbnail", thumbnail),
     ]:
         if value is not None:
             metadata[key] = value
@@ -152,6 +159,44 @@ def build_metadata(
         logger.error(f"Internal error: some metadata values are None: {metadata}")
 
     return metadata
+
+
+def latest_sample_image(output_dir: Optional[str]) -> Optional[str]:
+    """Most recently written preview under <output_dir>/sample/, if any.
+
+    Used as the default source for `modelspec.thumbnail` — training already produces these,
+    so a LoRA can carry a representative preview with no extra input from the user.
+    """
+    if not output_dir:
+        return None
+    sample_dir = os.path.join(output_dir, "sample")
+    if not os.path.isdir(sample_dir):
+        return None
+    exts = (".png", ".jpg", ".jpeg", ".webp")
+    candidates = [os.path.join(sample_dir, f) for f in os.listdir(sample_dir)
+                  if f.lower().endswith(exts)]
+    if not candidates:
+        return None
+    return max(candidates, key=os.path.getmtime)
+
+
+def thumbnail_data_uri(image_path: Optional[str], max_size: int = 512, quality: int = 85) -> Optional[str]:
+    """Downscale an image and embed it as a `modelspec.thumbnail` data URI (what ComfyUI's
+    model browser renders as the card art). Best-effort: a missing or broken thumbnail must
+    never fail a checkpoint save."""
+    if not image_path or not os.path.exists(image_path):
+        return None
+    try:
+        from PIL import Image
+        with Image.open(image_path) as im:
+            im = im.convert("RGB")
+            im.thumbnail((max_size, max_size))
+            buf = BytesIO()
+            im.save(buf, format="JPEG", quality=quality)
+        return f"data:image/jpeg;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+    except Exception:
+        logger.warning(f"could not build metadata thumbnail from {image_path}", exc_info=True)
+        return None
 
 
 def get_title(metadata: dict) -> Optional[str]:

--- a/src/fizgig/training/trainer.py
+++ b/src/fizgig/training/trainer.py
@@ -55,7 +55,7 @@ from fizgig.klein.model_utils import (
 from fizgig.klein.position import prc_img, prc_txt, scatter_ids, pack_control_latent
 from fizgig.modules.schedulers import FlowMatchDiscreteScheduler, RexLR
 from fizgig.training.metadata import (
-    build_metadata, latest_sample_image, thumbnail_data_uri,
+    build_metadata, latest_sample_image, thumbnail_data_uri, resolve_title,
     ARCHITECTURE_KLEIN_9B, ARCHITECTURE_KLEIN_9B_FULL,
 )
 from fizgig.training.train_utils import (
@@ -1826,6 +1826,10 @@ class KleinTrainer:
             img_path = os.path.join(save_dir, save_path + ".png")
             pil_image.save(img_path)
             logger.info(f"  Saved sample: {img_path}")
+            # Tracked so a checkpoint saved after this can default modelspec.description to
+            # the prompt that made its thumbnail, instead of shipping blank — same idea as the
+            # thumbnail itself, which is already whatever sample happens to be newest on disk.
+            self._last_sample_prompt = prompt
 
             if wandb_tracker is not None and wandb is not None:
                 wandb_tracker.log({f"sample_{prompt_idx}": wandb.Image(img_path)}, step=steps)
@@ -2319,7 +2323,8 @@ class KleinTrainer:
 
             metadata_to_save = minimum_metadata if args.no_metadata else metadata
 
-            title = args.metadata_title if args.metadata_title is not None else args.output_name
+            title = (args.metadata_title if args.metadata_title is not None
+                     else resolve_title(args.output_name, args.metadata_trigger_phrase))
             if args.min_timestep is not None or args.max_timestep is not None:
                 min_ts = args.min_timestep if args.min_timestep is not None else 0
                 max_ts = args.max_timestep if args.max_timestep is not None else 1000
@@ -2342,7 +2347,8 @@ class KleinTrainer:
                 title,
                 args.metadata_reso,
                 args.metadata_author,
-                args.metadata_description,
+                (args.metadata_description if args.metadata_description is not None
+                 else getattr(self, "_last_sample_prompt", None)),
                 args.metadata_license,
                 args.metadata_tags,
                 timesteps=md_timesteps,

--- a/src/fizgig/training/trainer.py
+++ b/src/fizgig/training/trainer.py
@@ -54,7 +54,10 @@ from fizgig.klein.model_utils import (
 )
 from fizgig.klein.position import prc_img, prc_txt, scatter_ids, pack_control_latent
 from fizgig.modules.schedulers import FlowMatchDiscreteScheduler, RexLR
-from fizgig.training.metadata import build_metadata, ARCHITECTURE_KLEIN_9B, ARCHITECTURE_KLEIN_9B_FULL
+from fizgig.training.metadata import (
+    build_metadata, latest_sample_image, thumbnail_data_uri,
+    ARCHITECTURE_KLEIN_9B, ARCHITECTURE_KLEIN_9B_FULL,
+)
 from fizgig.training.train_utils import (
     LossRecorder,
     get_epoch_ckpt_name,
@@ -2324,6 +2327,14 @@ class KleinTrainer:
             else:
                 md_timesteps = None
 
+            thumb_arg = args.metadata_thumbnail
+            if thumb_arg and thumb_arg.lower() in ("off", "none"):
+                thumb_source = None
+            elif thumb_arg:
+                thumb_source = thumb_arg
+            else:
+                thumb_source = latest_sample_image(args.output_dir)
+
             sai_metadata = build_metadata(
                 None,
                 self.architecture,
@@ -2335,6 +2346,8 @@ class KleinTrainer:
                 args.metadata_license,
                 args.metadata_tags,
                 timesteps=md_timesteps,
+                trigger_phrase=args.metadata_trigger_phrase,
+                thumbnail=thumbnail_data_uri(thumb_source),
             )
 
             metadata_to_save.update(sai_metadata)
@@ -3201,6 +3214,11 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--metadata_tags", type=str, default=None)
     parser.add_argument("--metadata_reso", type=str, default=None)
     parser.add_argument("--metadata_arch", type=str, default=None)
+    parser.add_argument("--metadata_trigger_phrase", type=str, default=None,
+                        help="Trigger word(s) recorded as modelspec.trigger_phrase")
+    parser.add_argument("--metadata_thumbnail", type=str, default=None,
+                        help="Path to an image to embed as modelspec.thumbnail. Omit to "
+                             "auto-use the latest sample preview; pass 'off' to disable.")
 
     # ---- Model paths ----
     parser.add_argument("--dit", type=str, help="Path to DiT checkpoint (.safetensors)")


### PR DESCRIPTION
Hiya,

I wanted richer metadata on saved LoRAs — the kind ComfyUI's model browser actually renders as
card art and info, not just the bare ss_* training params. Added `modelspec.trigger_phrase` and
`modelspec.thumbnail` (auto-embedded as a JPEG data URI from the latest training sample — no
extra input needed, it's already sitting right there in `<output_dir>/sample/`) to the
ModelSpec builder, and wired both through Klein and Krea 2 training, the CLI flags, and the GUI.

While I was in there I noticed Krea 2's per-epoch checkpoints weren't getting any ModelSpec
metadata at all — only the FINAL file got the modelspec.* block, and even that was missing
architecture/date/implementation. Moved Krea 2 onto the same builder Klein already used, so
every checkpoint gets the full block now, not just the last one.

Trigger phrase defaults to whatever's already in the Captions tab's trigger word field, so for
most people this needs zero extra input to just work.

edit: have also added a metadata tab that lets people view and change the metadata we're now writing.  Here's what it generally looks like for now (white text field has been changed to match color scheme).
<img width="3840" height="3697" alt="image" src="https://github.com/user-attachments/assets/de24238e-6a05-4624-bc4e-fb3b61600a9b" />

And here is how Comfy sees such a LoRA in the model viewer:
<img width="2039" height="1269" alt="image" src="https://github.com/user-attachments/assets/dbf83010-6c50-4fb9-bfe1-d7a5e15295f8" />
Very handy, IMHO.  Works similarly in sd.next, some lora organizers, etc.

edit2: added a little plumbing to shuttle around the prompt that generated the last sample, as it seems like a decent choice for default description metadata.  Users will have zero-effort "tagging" that includes an image, a keyword/title if they replaced the placeholders, a thumbnail, and a prompt suitable for generating the thumbnail.  For someone with CRS (can't remember stuff) like me, that's a huge boon when looking at berg2_style.safetensors ten months later (wtf is a berg!?).  

As an aside, "LoraName_TokenName" reads like it could be a template pattern rather than inert placeholder text.  I kept wondering which field on which tab I was failing to fill out to cause it to be expanded.  Something like "untitled_lora" would've been less confusing for me, personally.  If we see "LoraName_TokenName" as the lora name but have a keyword available, we're using the keyword as the title metadata instead.

Cheers,
FNG