### PR TITLE
minimax: load the H3 base from a directory of Hub shards

### DIFF
--- a/src/fizgig/krea2/safetensors_utils.py
+++ b/src/fizgig/krea2/safetensors_utils.py
@@ -291,6 +291,70 @@ class MemoryEfficientSafeOpen:
             raise ValueError(f"Unsupported float8 type: {dtype_str} (upgrade PyTorch to support float8 types)")
 
 
+class ShardedSafeOpen:
+    """A directory of sharded safetensors behind the MemoryEfficientSafeOpen interface.
+
+    Hugging Face serves large checkpoints as `model-0000N-of-0000M.safetensors` plus an index,
+    while every streaming loader here takes a single file. This adapts one to the other, so a
+    loader can accept either by dispatching on os.path.isdir.
+
+    Shards are opened lazily and kept open: a loader that walks named_parameters() in module
+    order touches each shard's keys contiguously, so this is a handful of file handles, not a
+    reopen per tensor. The index is trusted when present; without one the headers are read
+    (cheap — a header is a few tens of KB regardless of shard size).
+    """
+
+    def __init__(self, dirname: str, disable_numpy_memmap: bool = False):
+        self.dirname = dirname
+        self.disable_numpy_memmap = disable_numpy_memmap
+        self._readers: Dict[str, "MemoryEfficientSafeOpen"] = {}
+
+        entries = sorted(os.listdir(dirname))
+        index = [e for e in entries if e.endswith(".safetensors.index.json")]
+        if index:
+            with open(os.path.join(dirname, index[0]), "r", encoding="utf-8") as fh:
+                self.weight_map = json.load(fh)["weight_map"]
+        else:
+            shards = [e for e in entries if e.endswith(".safetensors")]
+            if not shards:
+                raise FileNotFoundError(f"{dirname}: no .safetensors shards")
+            self.weight_map = {}
+            for shard in shards:
+                with MemoryEfficientSafeOpen(os.path.join(dirname, shard)) as f:
+                    for key in f.keys():
+                        self.weight_map[key] = shard
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for reader in self._readers.values():
+            reader.file.close()
+        self._readers.clear()
+
+    def _reader(self, shard: str) -> "MemoryEfficientSafeOpen":
+        reader = self._readers.get(shard)
+        if reader is None:
+            reader = MemoryEfficientSafeOpen(os.path.join(self.dirname, shard), self.disable_numpy_memmap)
+            self._readers[shard] = reader
+        return reader
+
+    def keys(self):
+        return list(self.weight_map.keys())
+
+    def metadata(self) -> Dict[str, str]:
+        merged: Dict[str, str] = {}
+        for shard in dict.fromkeys(self.weight_map.values()):
+            merged.update(self._reader(shard).metadata())
+        return merged
+
+    def get_tensor(self, key: str, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None):
+        shard = self.weight_map.get(key)
+        if shard is None:
+            raise KeyError(f"{key} is not in any shard of {self.dirname}")
+        return self._reader(shard).get_tensor(key, device=device, dtype=dtype)
+
+
 def load_safetensors(
     path: str,
     device: Union[str, torch.device],

--- a/src/fizgig/minimax/loader.py
+++ b/src/fizgig/minimax/loader.py
@@ -18,6 +18,8 @@ that tensor, decode it if quantized, and place it —
 The frozen base is what LoRA/FT trains on top of; the fp32 output-head island stays fp32.
 """
 
+import os
+
 import torch
 import torch.nn as nn
 
@@ -25,7 +27,7 @@ import torch.nn as nn
 # safe_open(device="cpu").get_tensor() hard-crashes (access violation) in torch's storage
 # mmap-slicing. MemoryEfficientSafeOpen reads each tensor with a plain np.fromfile instead —
 # the same reader every other large-model loader in the repo uses. See embedder.py.
-from fizgig.krea2.safetensors_utils import MemoryEfficientSafeOpen
+from fizgig.krea2.safetensors_utils import MemoryEfficientSafeOpen, ShardedSafeOpen
 
 from .convrot import ConvRotInt8Linear, dequantize_int8_convrot, parse_comfy_quant
 from .model import MiniMaxH3DiT, MiniMaxH3Config
@@ -68,6 +70,10 @@ def load_minimax_h3_dit(path: str, device="cuda", compute_dtype=torch.bfloat16,
                         quantize=True, blocks_to_swap: int = 0, base_quant="auto") -> MiniMaxH3DiT:
     """Return a MiniMaxH3DiT with the real weights loaded, the base frozen.
 
+    `path` is either a single .safetensors file or a directory of Hub shards — the Hub serves
+    FL2VA/transformer as 13 shards + an index, which carry the same 535 key names the single
+    ComfyUI-converted file does.
+
     base_quant:
       "int8" — KEEP the checkpoint's int8 ConvRot weights (what the reference trainer does).
                ~0.17% error in the frozen base, ~21 GB resident. Needs a pre-quantized file.
@@ -83,7 +89,8 @@ def load_minimax_h3_dit(path: str, device="cuda", compute_dtype=torch.bfloat16,
     model.enable_block_swap(n) so the forward moves them just-in-time."""
     from bitsandbytes.nn import Linear4bit, Params4bit
 
-    with MemoryEfficientSafeOpen(path) as f:
+    opener = ShardedSafeOpen if os.path.isdir(path) else MemoryEfficientSafeOpen
+    with opener(path) as f:
         keys = set(f.keys())
         table_shape = None
         if "adaln_t_table" in keys:


### PR DESCRIPTION
## Why

`load_minimax_h3_dit` takes a single `.safetensors` file. The checkpoint as the Hub actually serves it — `MiniMaxAI/MiniMax-H3`, `FL2VA/transformer/` — is 13 shards plus an index, so using the official weights meant merging them into one 66 GB file first (a full extra copy on disk, and a slow one).

## What

`ShardedSafeOpen` puts a shard directory behind the existing `MemoryEfficientSafeOpen` interface (`keys` / `metadata` / `get_tensor` / context manager), so the loader dispatches on `os.path.isdir` and the streaming path below it is untouched:

```python
opener = ShardedSafeOpen if os.path.isdir(path) else MemoryEfficientSafeOpen
with opener(path) as f:
```

Both files have to land together — `loader.py` imports the new class.

Details:

- Shards open **lazily and stay open**. A loader that walks `named_parameters()` in module order touches each shard's keys contiguously, so this is a handful of file handles for the whole load, not a reopen per tensor.
- The index is trusted when present. Without one, headers are read to build the map — cheap, since a safetensors header is a few tens of KB regardless of shard size.
- Nothing about NF4/int8 quantization, block swap or the meta-device construction changes; this only swaps out where bytes come from.

Sits in `krea2/safetensors_utils.py` next to `MemoryEfficientSafeOpen` because it is generic — any other sharded checkpoint can use it — but nothing else calls it yet, so no existing path changes behaviour.

## Tested

Linux, RTX PRO 4000 Blackwell (25 GB), against the real `FL2VA/transformer` shard directory downloaded from the Hub:

- `keys()` returns **535** names; `MiniMaxH3DiT` (params + buffers) wants **535**; the intersection is complete — **zero** missing, **zero** unused. The Hub shard names are the same names the single ComfyUI-converted file carries, no renames.
- `weight_map` matches the Hub's `model.safetensors.index.json` exactly.
- Tensors read back with correct shapes/dtypes (`audio_patch_proj.weight` `(5376, 32)` fp32, `blocks.0.adaln_proj.linear.bias` `(96768,)` bf16), and handles close cleanly.
- Index-less fallback exercised by header scan.