### PR TITLE
minimax: let the H3 video VAE encode a clip, not just a still

### DIFF
--- a/src/fizgig/minimax/vae.py
+++ b/src/fizgig/minimax/vae.py
@@ -1,13 +1,14 @@
-"""MiniMax H3 video VAE — ENCODE PATH ONLY (image -> 24-channel latent).
+"""MiniMax H3 video VAE — ENCODE PATH ONLY (image or clip -> 24-channel latent).
 
 Pure-PyTorch port of the encoder half of ComfyUI's comfy/ldm/minimax/vae.py. Image-only
 training needs to turn a still image into the DiT's 24-channel latent exactly once (caching),
 so only the 3D-causal-CNN encoder + quant_conv + latent normalization are ported. The ViT3D
-decoder, spatial tiling and temporal chunking are omitted — no sampling/decode in scope.
+decoder and spatial/temporal tiling are omitted — no sampling/decode in scope.
 
 Weight names match the checkpoint's `encoder.*` / `quant_conv.*` / `latents_mean/std`, so the
 official minimax_h3_video_vae_fp16.safetensors loads with strict=False (decoder/post_quant keys
-ignored). A single image is one video frame (T=1): 16x spatial downscale, T stays 1.
+ignored). 16x spatial downscale; 4x causal temporal downscale, so a still (T=1) stays T=1 and a
+clip of T frames yields ceil(T/4) latent frames.
 """
 
 import math
@@ -164,15 +165,20 @@ class MiniMaxH3VideoVAEEncoder(nn.Module):
 
     @torch.no_grad()
     def encode(self, x):
-        """x: [B,3,H,W] or [B,3,T,H,W] in [-1,1] -> normalized latent [B,24,1,H/16,W/16] (image: T=1)."""
+        """x: [B,3,H,W] or [B,3,T,H,W] in [-1,1] -> normalized latent [B,24,ceil(T/4),H/16,W/16].
+
+        The stack is temporally causal with a 4x stride, so latent frame k depends only on pixel
+        frames up to 4k (verified by perturbation) and a still gives T'=1 — the image path is
+        unchanged. Feed 1+4k frames for a clean 1+k latent frames.
+
+        No temporal chunking: peak activation is dominated by the first level at full T x H x W,
+        so long clips want tiling that this port does not implement. Encode in clips.
+        """
         if x.ndim == 4:
             x = x.unsqueeze(2)
         x = (x + 1.0) * 0.5
         x = (x - self.pixel_mean.to(x)) / self.pixel_std.to(x)
-        if x.shape[2] != 1:
-            raise NotImplementedError("MiniMax H3 image training encodes a single frame (T=1)")
         moments = self.quant_conv(self.encoder(x))
-        moments = moments[:, :, -1:, :, :]
         mean = torch.chunk(moments.float(), 2, dim=1)[0]
         lm = self.latents_mean.view(1, -1, 1, 1, 1).to(mean)
         ls = self.latents_std.view(1, -1, 1, 1, 1).to(mean)


### PR DESCRIPTION
## Why

694c2f9 made the DiT and the VAE **decode** path multi-frame. Encode was the one place still pinned to `T=1`:

```python
if x.shape[2] != 1:
    raise NotImplementedError("MiniMax H3 image training encodes a single frame (T=1)")
moments = self.quant_conv(self.encoder(x))
moments = moments[:, :, -1:, :, :]
```

Two guards, one behind the other — even a clip that got past the raise would have come back as a single latent frame from the slice.

## What

Both lines drop. The encoder stack is *already* temporally causal with a 4x stride, so they were guards rather than load-bearing machinery: removing them gives `T_latent == ceil(T_pixel / 4)`, and the still case (`T=1 -> 1`) is untouched. Only docstrings otherwise.

## Tested

Linux, RTX PRO 4000 Blackwell (25 GB), real released weights (`minimax_h3_video_vae_fp16.safetensors`), 64x64 latents, fp16.

**Shape rule** — every length matches `ceil(T/4)`:

| T_pixel | 1 | 2 | 4 | 5 | 9 | 17 | 21 | 22 | 25 | 29 |
|---|---|---|---|---|---|---|---|---|---|---|
| T_latent | 1 | 1 | 1 | 2 | 3 | 5 | 6 | 6 | 7 | 8 |

**Causality by perturbation** — rewriting pixel frame 28 of a 29-frame clip moves only latent frame 7:

```
0:0.0000  1:0.0000  2:0.0000  3:0.0000  4:0.0000  5:0.0000  6:0.0000  7:1.1283
```

Frames 0–6 come back bit-identical, so no latent frame sees pixels from its future.

Also used in anger: a 29-frame 512x512 clip encodes to `[1, 24, 8, 32, 32]`, and fp16 vs fp32 encode agrees to cosine 0.9999996 / rel L2 0.0023 (fp32 at this size hits allocator thrash on a 25 GB card, so fp16 is the practical path).

## One caveat worth stating

This encode grid (`1+4k` pixels -> `1+k` latents) is **not** the inverse of `decode_clip`'s sampling grid (`5n+2` latents <-> `17n+5` pixels): 22 frames encode to 6 latents, where `pixel_frames_for_latent(7) == 22`. That is inherent to the encoder — the reference's encode-side temporal chunking is still not ported — so I have left it alone rather than papering over it here. Just don't pair the two for a round trip without checking the grid.

No temporal chunking on encode: peak activation is dominated by the first level at full `T x H x W`, so very long clips still want tiling this port does not implement. Encode in clips.