### PR TITLE
Royale/Explorer/Repair Studio: check LoRA family before loading a pipeline

### DIFF
--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -13615,6 +13615,19 @@ class LoRATrainerGUI:
         if not path or not os.path.exists(path):
             messagebox.showerror("Error", "Pick a valid LoRA file first.")
             return
+        # Auto-follow the file's family (issue #62 nice-to-have): detected from the header
+        # alone, microseconds, so do it BEFORE _explorer_ensure_engine() commits to loading
+        # the wrong family's DiT/VAE/TE. Only a genuinely unrecognized file falls through to
+        # the generic error below, same as before.
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        detected = lora_family_from_file(path)
+        selected = "krea2" if self._explorer_is_krea2() else "klein"
+        if detected is not None and detected != selected:
+            self.explorer_family_var.set(detected)
+            self._on_explorer_family_changed()
+            self.explorer_status_var.set(
+                f"Switched family selector to {FAMILY_DISPLAY_NAMES.get(detected, detected)} "
+                f"to match {os.path.basename(path)}.")
         if not self._explorer_ensure_engine():
             return
         try:
@@ -19207,6 +19220,57 @@ class LoRATrainerGUI:
         eng = getattr(self, "royale_engine", None)
         return eng is not None and type(eng).__name__ == "Krea2RepairEngine"
 
+    def _royale_check_lora_families(self, *paths):
+        """Main-thread pre-flight for issue #62: auto-follow the selector to match the batch's
+        detected family BEFORE any worker thread starts, so picking a file never means eating
+        the 9 GB pipeline load just to be told it doesn't match. Uses the exact same
+        _on_royale_family_changed() a manual radio click would, so the engine ends up in the
+        same state either way, and the switch is visible (radio button + status line) rather
+        than silent. Call BEFORE _royale_validate_models(), not after — a switch here resets
+        royale_engine to None, and _royale_validate_models() is what recreates it (and stashes
+        the family-shaped pipeline kwargs); reversing the order leaves the worker thread calling
+        ensure_pipeline() on a None engine with kwargs stashed for the family being switched
+        away from. Both run before the threading.Thread(...).start() that kicks off the heavy
+        work — _royale_load_or_swap_primary still carries a raise-based version of this check
+        for mid-run epoch swaps on the worker thread, where touching Tk state isn't safe.
+
+        Accepts multiple paths (e.g. a whole epoch selection). The target family is decided from
+        the WHOLE batch first — not path-by-path, which would let an already-matching first path
+        mask a mismatched later one when a switch fires mid-loop — so a genuinely mixed-family
+        selection is always caught rather than depending on which order the paths happen to be
+        in. None paths are skipped so callers can pass tuples straight from
+        _royale_current_epoch(). Only shows a dialog when it can't resolve things automatically
+        (a second family in the same selection); an unrecognized file is simply ignored."""
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        seen = []          # (path, family) for every path with a determinable family
+        checked = set()
+        for path in paths:
+            if not path or path in checked:
+                continue
+            checked.add(path)
+            detected = lora_family_from_file(path)
+            if detected is not None:
+                seen.append((path, detected))
+        if not seen:
+            return True  # nothing recognizable — fail open, let the real loader be the judge
+        target_path, target = seen[0]
+        for path, detected in seen[1:]:
+            if detected != target:
+                messagebox.showerror(
+                    "Mixed LoRA families",
+                    f"{os.path.basename(path)} was trained for {FAMILY_DISPLAY_NAMES.get(detected, detected)}, "
+                    f"but this selection also includes {FAMILY_DISPLAY_NAMES.get(target, target)} files "
+                    f"(e.g. {os.path.basename(target_path)}). Pick LoRAs from a single family.")
+                return False
+        selected = str(self.royale_family_var.get())
+        if target != selected:
+            target_name = FAMILY_DISPLAY_NAMES.get(target, target)
+            self.royale_family_var.set(target)
+            self._on_royale_family_changed()
+            self.royale_status_var.set(
+                f"Switched family selector to {target_name} to match {os.path.basename(target_path)}.")
+        return True
+
     def _royale_ensure_pipeline_loaded(self):
         """Worker-thread: load the preview pipeline if it isn't already. No Tk calls;
         raises on failure (callers route it to their finish handler). The same load
@@ -19220,7 +19284,14 @@ class LoRATrainerGUI:
     def _royale_load_or_swap_primary(self, eng, path):
         """Point `eng` at `path`. Fast in-place weight swap when the structure matches
         (same-rank epochs); otherwise reset() + rebuild the pipeline + load_primary so a
-        different-rank / unrelated LoRA loads cleanly. Worker-thread safe (no Tk)."""
+        different-rank / unrelated LoRA loads cleanly. Worker-thread safe (no Tk).
+
+        Checks the file's family against the selector BEFORE any of that (issue #62):
+        every Royale entry point (render, comparison, seed-travel, LoRA-strength-travel)
+        already calls this one function inside its own try/except, so one guard here
+        covers all of them without touching each worker."""
+        from fizgig.networks.lora import assert_lora_family_matches
+        assert_lora_family_matches(path, str(self.royale_family_var.get()), "Royale")
         if eng.primary_network is None:
             eng.load_primary(path)
             return
@@ -19262,6 +19333,8 @@ class LoRATrainerGUI:
             if len(cps) > n:
                 idx = sorted({round(i * (len(cps) - 1) / (n - 1)) for i in range(n)})
                 sel = [cps[i] for i in idx]
+        if not self._royale_check_lora_families(*[p for _, p in sel]):
+            return
         if not self._royale_validate_models():
             return
         self._royale_rendering = True
@@ -19843,6 +19916,8 @@ class LoRATrainerGUI:
             frames = int(self.royale_travel_frames_var.get())
         except ValueError:
             frames = 24
+        if not self._royale_check_lora_families(path):
+            return
         if not self._royale_validate_models():
             return
         try:
@@ -19951,6 +20026,8 @@ class LoRATrainerGUI:
             frames = int(self.royale_lora_frames_var.get())
         except ValueError:
             frames = 24
+        if not self._royale_check_lora_families(path):
+            return
         if not self._royale_validate_models():
             return
         try:
@@ -20090,6 +20167,8 @@ class LoRATrainerGUI:
                                                    "to the one you want to showcase.")
                 return
             cols = [(None, path), (label, path)]      # column 0 renders at strength 0 (base model)
+        if not self._royale_check_lora_families(*[p for _, p in cols]):
+            return
         if not self._royale_validate_models():
             return
         try:
@@ -20477,6 +20556,8 @@ class LoRATrainerGUI:
             width = int(self.royale_pt_w_var.get()); height = int(self.royale_pt_h_var.get())
         except ValueError:
             width = height = 512
+        if not self._royale_check_lora_families(path):
+            return
         if not self._royale_validate_models():
             return
         params = dict(
@@ -20613,6 +20694,19 @@ class LoRATrainerGUI:
         if not path or not os.path.exists(path):
             messagebox.showerror("Error", "Pick a valid primary LoRA file first.")
             return
+        # Auto-follow the file's family (issue #62 nice-to-have): detected from the header
+        # alone, microseconds, so do it BEFORE _ensure_repair_engine() commits to loading the
+        # wrong family's DiT/VAE/TE. Only a genuinely unrecognized file falls through to the
+        # generic error below, same as before.
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        detected = lora_family_from_file(path)
+        selected = "krea2" if self.repair_family_var.get() == "krea2" else "klein"
+        if detected is not None and detected != selected:
+            self.repair_family_var.set(detected)
+            self._on_repair_family_changed()
+            self.repair_status_var.set(
+                f"Switched family selector to {FAMILY_DISPLAY_NAMES.get(detected, detected)} "
+                f"to match {os.path.basename(path)}.")
         if not self._ensure_repair_engine():
             return
         try:

--- a/lora_trainer_gui.py
+++ b/lora_trainer_gui.py
@@ -13619,8 +13619,18 @@ class LoRATrainerGUI:
         # alone, microseconds, so do it BEFORE _explorer_ensure_engine() commits to loading
         # the wrong family's DiT/VAE/TE. Only a genuinely unrecognized file falls through to
         # the generic error below, same as before.
-        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES, INFERENCE_FAMILIES
         detected = lora_family_from_file(path)
+        if detected is not None and detected not in INFERENCE_FAMILIES:
+            # The Explorer only offers Klein 9B / Krea 2 radios — setting the var to a
+            # detected MiniMax H3 (or any future train-only family) leaves both radios
+            # blank instead of following it. Refuse rather than land on a family this tab
+            # has no engine for.
+            messagebox.showerror(
+                "Unsupported family",
+                f"{os.path.basename(path)} was trained for {FAMILY_DISPLAY_NAMES.get(detected, detected)}, "
+                f"but the Explorer doesn't support {FAMILY_DISPLAY_NAMES.get(detected, detected)} LoRAs yet.")
+            return
         selected = "krea2" if self._explorer_is_krea2() else "klein"
         if detected is not None and detected != selected:
             self.explorer_family_var.set(detected)
@@ -19241,7 +19251,7 @@ class LoRATrainerGUI:
         in. None paths are skipped so callers can pass tuples straight from
         _royale_current_epoch(). Only shows a dialog when it can't resolve things automatically
         (a second family in the same selection); an unrecognized file is simply ignored."""
-        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES, INFERENCE_FAMILIES
         seen = []          # (path, family) for every path with a determinable family
         checked = set()
         for path in paths:
@@ -19262,6 +19272,17 @@ class LoRATrainerGUI:
                     f"but this selection also includes {FAMILY_DISPLAY_NAMES.get(target, target)} files "
                     f"(e.g. {os.path.basename(target_path)}). Pick LoRAs from a single family.")
                 return False
+        if target not in INFERENCE_FAMILIES:
+            # Royale only offers Klein 9B / Krea 2 radios — setting the var to anything else
+            # (e.g. a detected MiniMax H3 LoRA) leaves both radios blank and silently falls
+            # back to Klein internally (issue #62 review, shootthesound). Refuse outright
+            # instead of following into a family this tab can't actually render.
+            messagebox.showerror(
+                "Unsupported family",
+                f"{os.path.basename(target_path)} was trained for "
+                f"{FAMILY_DISPLAY_NAMES.get(target, target)}, but Royale doesn't support "
+                f"{FAMILY_DISPLAY_NAMES.get(target, target)} LoRAs yet.")
+            return False
         selected = str(self.royale_family_var.get())
         if target != selected:
             target_name = FAMILY_DISPLAY_NAMES.get(target, target)
@@ -20698,8 +20719,18 @@ class LoRATrainerGUI:
         # alone, microseconds, so do it BEFORE _ensure_repair_engine() commits to loading the
         # wrong family's DiT/VAE/TE. Only a genuinely unrecognized file falls through to the
         # generic error below, same as before.
-        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES
+        from fizgig.networks.lora import lora_family_from_file, FAMILY_DISPLAY_NAMES, INFERENCE_FAMILIES
         detected = lora_family_from_file(path)
+        if detected is not None and detected not in INFERENCE_FAMILIES:
+            # Repair Studio only offers Klein 9B / Krea 2 radios — setting the var to a
+            # detected MiniMax H3 (or any future train-only family) leaves both radios
+            # blank instead of following it. Refuse rather than land on a family this tab
+            # has no engine for.
+            messagebox.showerror(
+                "Unsupported family",
+                f"{os.path.basename(path)} was trained for {FAMILY_DISPLAY_NAMES.get(detected, detected)}, "
+                f"but Repair Studio doesn't support {FAMILY_DISPLAY_NAMES.get(detected, detected)} LoRAs yet.")
+            return
         selected = "krea2" if self.repair_family_var.get() == "krea2" else "klein"
         if detected is not None and detected != selected:
             self.repair_family_var.set(detected)

--- a/src/fizgig/networks/lora.py
+++ b/src/fizgig/networks/lora.py
@@ -1765,6 +1765,26 @@ FAMILY_DISPLAY_NAMES = {
     "minimax": "MiniMax H3",
 }
 
+# Families that actually have an inference-side selector (Royale, Explorer, Repair Studio all
+# offer only these two radios). MiniMax H3 is train-only right now — no engine, no pipeline, no
+# widget for it in any of those tabs — so a caller auto-following lora_family_from_file's result
+# must refuse rather than tk.StringVar.set() a value neither radio button carries (issue #62
+# follow-up: the var still holds it, both radios go blank, and the family that actually loads is
+# whichever one the "else" branch of the caller's own is_krea2 ternary falls back to).
+INFERENCE_FAMILIES = ("klein", "krea2")
+
+# Klein 9B's block depth (Klein9BParams in klein/model.py: depth=8, depth_single_blocks=24).
+# double_blocks/single_blocks (native/kohya) and transformer_blocks/single_transformer_blocks
+# (diffusers) are BFL naming shared with other Flux variants at different depths — Flux.1
+# dev/schnell is 19+38, full Flux.2 is 8+48 — so the family can't be read off the block-name
+# substring alone; the deepest block index actually present has to fall inside Klein's own
+# shape. A negative lookbehind keeps "single_transformer_blocks.N" from also matching the
+# double/transformer_blocks pattern (it contains "transformer_blocks.N" as a substring).
+_KLEIN_MAX_DOUBLE_BLOCKS = 8
+_KLEIN_MAX_SINGLE_BLOCKS = 24
+_KLEIN_DOUBLE_BLOCK_RE = re.compile(r"(?<!single_)(?:double_blocks|transformer_blocks)[._](\d+)")
+_KLEIN_SINGLE_BLOCK_RE = re.compile(r"single_(?:transformer_)?blocks[._](\d+)")
+
 
 def lora_family_from_file(path: str) -> Optional[str]:
     """Identify which model family a LoRA/LyCORIS file was trained for, from its
@@ -1772,13 +1792,17 @@ def lora_family_from_file(path: str) -> Optional[str]:
 
     Returns "klein", "krea2", "minimax", or None if the file doesn't match any
     known signature (callers should not block on None — fail open and let the
-    real loader be the judge, the same as an unreadable/corrupt file).
+    real loader be the judge, the same as an unreadable/corrupt file). None also
+    covers a file that uses Klein's own block-name segments at a depth Klein 9B
+    doesn't have (a Flux.1 or full-Flux.2 LoRA) — see _KLEIN_MAX_DOUBLE_BLOCKS.
 
-    The three families never share a discriminating substring, so a plain
-    membership check on the raw key strings is enough — it works whether the file
-    uses Fizgig's own native prefixes (`diffusion_model.`, `transformer.`), the
-    kohya/sd-scripts flattened form (`lora_unet_*`), or another tool's dotted
-    diffusers export; none of those rewrite the block-name segments checked here.
+    Krea 2 and MiniMax H3 are each identified by a substring nothing else uses, so a
+    plain membership check is enough for them regardless of whether the file uses
+    Fizgig's own native prefixes (`diffusion_model.`, `transformer.`), the kohya/
+    sd-scripts flattened form (`lora_unet_*`), or another tool's dotted diffusers
+    export. Klein 9B shares its block-name segments with other Flux depths, so it's
+    identified by block count instead (checked last, after Krea 2 and MiniMax H3 are
+    ruled out — diffusers-form Krea 2 also says `transformer_blocks.`).
     """
     from fizgig.utils.safetensors import MemoryEfficientSafeOpen
     try:
@@ -1787,14 +1811,27 @@ def lora_family_from_file(path: str) -> Optional[str]:
     except Exception:
         return None
     for k in keys:
-        if "double_blocks" in k or "single_blocks" in k:
-            return "klein"
-    for k in keys:
         if "text_fusion" in k or "txtfusion" in k:
             return "krea2"
+    if _is_diffusers_krea2_lora(keys):
+        return "krea2"
     for k in keys:
         if "token_refiner" in k or "adaln_proj" in k:
             return "minimax"
+    max_double = -1
+    max_single = -1
+    for k in keys:
+        m = _KLEIN_DOUBLE_BLOCK_RE.search(k)
+        if m:
+            max_double = max(max_double, int(m.group(1)))
+            continue
+        m = _KLEIN_SINGLE_BLOCK_RE.search(k)
+        if m:
+            max_single = max(max_single, int(m.group(1)))
+    if max_double < 0 and max_single < 0:
+        return None
+    if max_double < _KLEIN_MAX_DOUBLE_BLOCKS and max_single < _KLEIN_MAX_SINGLE_BLOCKS:
+        return "klein"
     return None
 
 

--- a/src/fizgig/networks/lora.py
+++ b/src/fizgig/networks/lora.py
@@ -1749,6 +1749,74 @@ class UnsupportedLoRAFormat(RuntimeError):
     decompositions that would need separate module classes."""
 
 
+class LoRAFamilyMismatch(RuntimeError):
+    """Raised when a LoRA's trained-for family doesn't match the family a caller
+    (Royale / Explorer / Repair Studio) is about to load it against. Callers should
+    catch this the same way they catch UnsupportedLoRAFormat — a clean single-line
+    message, no traceback — since it's an expected user-facing outcome, not a bug."""
+
+
+# Family display names, keyed by the same "klein" / "krea2" / "minimax" strings the
+# GUI's *_family_var StringVars already use — lets callers compare lora_family_from_file's
+# result against a family_var.get() directly with no translation step.
+FAMILY_DISPLAY_NAMES = {
+    "klein": "Klein 9B",
+    "krea2": "Krea 2",
+    "minimax": "MiniMax H3",
+}
+
+
+def lora_family_from_file(path: str) -> Optional[str]:
+    """Identify which model family a LoRA/LyCORIS file was trained for, from its
+    safetensors header alone — no tensor data read, no pipeline load, microseconds.
+
+    Returns "klein", "krea2", "minimax", or None if the file doesn't match any
+    known signature (callers should not block on None — fail open and let the
+    real loader be the judge, the same as an unreadable/corrupt file).
+
+    The three families never share a discriminating substring, so a plain
+    membership check on the raw key strings is enough — it works whether the file
+    uses Fizgig's own native prefixes (`diffusion_model.`, `transformer.`), the
+    kohya/sd-scripts flattened form (`lora_unet_*`), or another tool's dotted
+    diffusers export; none of those rewrite the block-name segments checked here.
+    """
+    from fizgig.utils.safetensors import MemoryEfficientSafeOpen
+    try:
+        with MemoryEfficientSafeOpen(path) as f:
+            keys = f.keys()
+    except Exception:
+        return None
+    for k in keys:
+        if "double_blocks" in k or "single_blocks" in k:
+            return "klein"
+    for k in keys:
+        if "text_fusion" in k or "txtfusion" in k:
+            return "krea2"
+    for k in keys:
+        if "token_refiner" in k or "adaln_proj" in k:
+            return "minimax"
+    return None
+
+
+def assert_lora_family_matches(path: str, selected_family: str, tab_label: str) -> None:
+    """Guard for the family/LoRA mismatch in issue #62: check the file's family against
+    what the tab's selector is set to BEFORE a caller commits to a full pipeline load.
+    No-op when the file's family can't be determined (fail open) or already matches.
+
+    Raises LoRAFamilyMismatch with a plain-English message on a real mismatch — callers
+    should catch it alongside UnsupportedLoRAFormat and show it without a traceback.
+    """
+    detected = lora_family_from_file(path)
+    if detected is None or detected == selected_family:
+        return
+    detected_name = FAMILY_DISPLAY_NAMES.get(detected, detected)
+    selected_name = FAMILY_DISPLAY_NAMES.get(selected_family, selected_family)
+    raise LoRAFamilyMismatch(
+        f"This LoRA was trained for {detected_name}, but the {tab_label} family selector "
+        f"is on {selected_name}. Switch it to {detected_name} to use this file."
+    )
+
+
 def ensure_kohya_lora_state_dict(weights_sd: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     """Convert the state dict to kohya module-name convention if needed.
     Pass-through for already-kohya files. Raises UnsupportedLoRAFormat for


### PR DESCRIPTION
Closes #62.
## What this does

Adds `lora_family_from_file(path)` in `networks/lora.py`: identifies which family a LoRA was trained for straight from its safetensors header — no tensor data, no pipeline load, microseconds. Klein 9B (`double_blocks`/`single_blocks`), Krea 2 (`text_fusion`/`txtfusion`), and MiniMax H3 (`token_refiner`/`adaln_proj`) each have non-overlapping key-name signatures, so a plain substring check is enough — works whether the file uses Fizgig's own native prefixes, kohya/sd-scripts flattening, or another tool's diffusers export.

Royale, LoRA the Explorer, and Repair Studio now auto-follow the family selector to match a picked file instead of committing to a full pipeline load and then failing with `No LoRA modules found` after ~25s and ~260 lines of LyCORIS skip warnings. The switch uses the same path a manual radio click takes, so the engine ends up correctly rebuilt either way, and it's visible (radio flips, status line explains why) rather than silent.

## Where the checks live

- **Royale**: all 5 entry points that lead to a pipeline load (render, comparison, seed-travel, LoRA-strength-travel, prompt-travel) check *before* `_royale_validate_models()` runs — that function is what creates `royale_engine` and stashes the family-shaped pipeline kwargs, so checking after would leave a just-switched selector pointing at a stale/None engine. A second, worker-thread-safe raise-based guard (`LoRAFamilyMismatch`) stays in `_royale_load_or_swap_primary` for mid-run epoch swaps, where touching Tk state from a worker thread isn't safe.
- **Explorer / Repair Studio**: check runs before their respective `_ensure_engine()` calls, for the same reason.
- A mixed-family batch (e.g. a Royale folder with epochs from two different runs) still errors cleanly rather than silently picking one — the target family is decided from the whole batch first, not path-by-path, so it doesn't depend on which file happens to come first.

## Testing

No test suite in the repo, so verified by hand:
- `lora_family_from_file` against real Klein 9B (LoKR) and Krea 2 (LoRA) files — correct family, sub-millisecond.
- Match / mismatch / mixed-batch / unreadable-file cases run directly against the real files.
- Live in the app: Royale seed-travel and the Comparison Sheet, family selector on Klein 9B pointed at a Krea 2 file — radio switched live, correct pipeline loaded, render completed.

## Summary by Sourcery

Add lightweight LoRA family detection and integrate it into Royale, Explorer, and Repair Studio to avoid loading mismatched pipelines and to surface clear, user-facing feedback when families differ.

New Features:
- Introduce safetensors-header-based detection of Klein 9B, Krea 2, and MiniMax H3 LoRA families without loading tensor data.
- Automatically align family selectors in Royale, Explorer, and Repair Studio with the chosen LoRA file when a recognizable mismatch is detected.

Bug Fixes:
- Prevent slow, failed pipeline loads caused by attempting to use a LoRA with the wrong model family by checking families up front.

Enhancements:
- Add mixed-family batch validation in Royale entry points so selections containing multiple families are rejected with a clear error instead of partially succeeding.
- Provide a reusable assertion helper and a dedicated LoRAFamilyMismatch error to standardize handling of family mismatches across tabs and worker-thread code paths.