### PR TITLE
deps: bump Pillow 11.3.0 -> 12.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ toml==0.10.2
 voluptuous==0.15.2
 
 # Image processing
-pillow==11.3.0
+pillow==12.3.0
 numpy>=1.26.4,<3  # range, not a hard pin — over-constraining numpy breaks pip resolution on some setups (issue #4). torch 2.10 supports numpy 1.26+ and 2.x.
 opencv-python==4.10.0.84
 imageio-ffmpeg>=0.5  # bundled ffmpeg → LoRA Royale exports web-standard H.264 MP4 (Reddit/X/IG), no system ffmpeg needed

--- a/src/fizgig/krea2/trainer.py
+++ b/src/fizgig/krea2/trainer.py
@@ -298,6 +298,10 @@ def _find_host_compiler() -> bool:
         if not os.path.isfile(vcvars):
             continue
         try:
+            # shell=True is intentional here: vcvars is a path just discovered via vswhere/
+            # well-known VS install roots (not external input), and we need the shell's &&
+            # to source the .bat file's env vars into `set`. cmd.exe /c would hit the same
+            # interpreter anyway, so it'd be cosmetic, not safer.
             out = subprocess.run(f'"{vcvars}" >nul && set', shell=True, capture_output=True,
                                  text=True, timeout=120)
             if out.returncode != 0:


### PR DESCRIPTION
Bumps Pillow 11.3.0 → 12.3.0 to pick up the CVE-2026-54058 fix, and adds the `shell=True` documentation comment — the two follow-ups from #64.

- Spot-checked the image-load surface (open/new/fromarray/resize/thumbnail/blend/alpha_composite/Draw), including the old-style `Image.LANCZOS`/`NEAREST`/`BICUBIC` constants used across the resize call sites — all still work fine in 12.3.0, no renames needed.
- Checked Pillow 12.0.0's breaking-change list against the codebase (`ImageMath.eval`, `getdraw()` hints param, `BGR;15/16/24` modes, `raise_oserror`, Python 3.9 support) — none of these are used or apply here.

Refs #64
