### PR TITLE
minimax: parking the DiT no longer corrupts H2D-swapped blocks

### DIFF
--- a/src/fizgig/minimax/h3_h2d_offload.py
+++ b/src/fizgig/minimax/h3_h2d_offload.py
@@ -291,6 +291,27 @@ class H3Int8H2DOffloader:
         self.ring_views = None
         torch.cuda.empty_cache()
 
+    def unbind_to_cpu(self):
+        """Point every managed module back at its pinned CPU master, changing nothing else.
+
+        park_dit_partial evicts CUDA buffers by resizing their storages to zero — correct
+        for real weights, fatal for these bindings: after a forward, a swapped block's
+        qdata/wscale still point at RING VIEWS, and every view of a slot shares ONE
+        storage. Parking the first view resize_(0)s the whole slot, and the very next
+        buffer copied from that storage dies with CUDA 'invalid argument' — a sticky
+        context error that then kills the preview decode and the first training step
+        (field: 24 GB card, auto plan swap 6, 56-frame clip preview at 4.9 GB free; run
+        died at step 0/6900 in the rebuilt offloader's first ring copy). The swapped
+        blocks' weights already live on CPU in the pinned flats, so re-binding lets the
+        park's walk skip them exactly as its "already on CPU, skipped as not-cuda" rule
+        assumes. Slot bookkeeping resets too, so a wait_for_block() that somehow runs
+        before the next restore self-heals a reload instead of trusting stale bindings."""
+        for block_idx in self.sources:
+            self._bind_cpu(block_idx)
+        self.loaded_block = [None] * self.ring_size
+        self.free_event = [None] * self.ring_size
+        self.copy_done.clear()
+
     def __del__(self):
         try:
             for handle in getattr(self, "remove_handles", []):

--- a/src/fizgig/minimax/trainer.py
+++ b/src/fizgig/minimax/trainer.py
@@ -158,6 +158,17 @@ def park_dit_partial(dit, need_gb=None):
     target = float("inf") if need_gb is None else max(0.0, float(need_gb)) * 1e9
     _alloc0 = torch.cuda.memory_allocated() if torch.cuda.is_available() else 0
 
+    # Under H2D swap, the swapped blocks' qdata/wscale LOOK cuda-resident to the walk below
+    # (they point at ring staging views), and evicting one view resize_(0)s the whole shared
+    # slot storage — the next copy from that storage is a sticky CUDA 'invalid argument'
+    # that killed the preview decode and the first training step (24 GB card, swap 6, 56-
+    # frame preview at 4.9 GB free; step 0/6900 died in the rebuilt offloader). Their real
+    # masters are already on CPU in the offloader's pinned flats: re-bind, and the walk
+    # skips them exactly as its own "already on CPU" rule intends.
+    _off = getattr(dit, "_h2d_offloader", None)
+    if _off is not None:
+        _off.unbind_to_cpu()
+
     def _park_module(mod, prefix):
         nonlocal freed
         for name, t in (list(mod.named_parameters(prefix=prefix))


### PR DESCRIPTION
## What breaks

Training MiniMax H3 from the GUI with default flags crashes at step 0 with `torch.AcceleratorError: CUDA error: invalid argument`, but the traceback points into `h3_h2d_offload.py:_load` — nowhere near the real failure.

## Root cause

The GUI locks `--optimizer_type adamw` (fp32 state) and `--no_train_adaln`, which shifts the auto VRAM planner to **swap 6** instead of swap 0. With 6 blocks swapped, free VRAM at preview time lands below the 7.5 GB threshold, so the preview-decode **park path** (`park_dit_partial`) triggers.

Under H2D swap, a swapped block's `qdata`/`wscale` registered buffers stay bound to **views of one GPU ring-slot storage** (all views of a slot share a single storage). `park_dit_partial._park_module` evicts each buffer with `t.data = slot; _storage.resize_(0)` — resizing the first view (`qdata`) destroys the **entire shared slot storage**, and the very next buffer from the same storage (`wscale`, now `storage_nbytes=0`) fails its `slot.copy_(t.data)` with `invalid argument`. CUDA context errors are sticky: preview decode dies, the `finally`-block restore rebuilds the offloader, and step 0's first ring copy surfaces the stale error from `_load`.

Evidence from an instrumented run: pre-park `synchronize` clean, `blocks.49.attn.qkv_proj.qdata` copied OK, then `FAILED at blocks.49.attn.qkv_proj.wscale ... storage_nbytes=0`.

CLI repros with trainer-default flags missed this entirely, because `adamw8bit` plans swap 0 and never parks.

## The fix

The park walk always *assumed* swapped blocks were already on CPU and would be skipped as not-cuda — that was false while ring views were still bound. New `H3Int8H2DOffloader.unbind_to_cpu()` rebinds every managed module to its pinned CPU master and resets slot bookkeeping (so a stray `wait_for_block` self-heals); `park_dit_partial` calls it before the walk. Since `park_dit_to_cpu` delegates to `park_dit_partial`, one call covers both park paths.

## Verification

24 GB RTX 3090, GUI-equivalent flags (int8 base, swap 6, adamw, 56-frame clip preview with audio): park succeeds, preview clip + wav + mp4 decode and write, 115/115 steps at 1.59 s/it, avr_loss 0.5334, LoRA saved. A later restore-time OOM was caught and handled by the frame ladder — training continued and completed.


💘 Generated with Crush