### PR TITLE
Drop the gfx12 batched-GEMM workaround

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@ Fizgig is written by [Peter Neill (shootthesound)](https://github.com/shoottheso
 [scryptio](https://github.com/scryptio) built the **AMD ROCm support** that headlines v4.3.0
 ([#53](https://github.com/shootthesound/Fizgig/pull/53)): the Windows and Linux ROCm install
 paths and launchers, GPU architecture detection, cross-platform VRAM monitoring for the status
-bar, and the RDNA4 batched-GEMM workaround — a lot of building and testing on real hardware.
+bar — a lot of building and testing on real hardware.
 Along the way the same investigation pinned down the torch.compile recompile cost on
 ROCm, now handled automatically. The PR thread was a group effort:
 [tsubasasora](https://github.com/tsubasasora) ran repeated from-scratch Linux installs on an

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Then double-click `install_fizgig_rocm.bat` (NVIDIA users never run this). It pi
 - `torchvision==0.27.0+rocm7.15.0a20260728`
 - `rocm-sdk-devel==7.15.0a20260728`
 
-Override with `TORCH_PIN` / `TORCHVISION_PIN` / `ROCM_SDK_DEVEL_PIN` if needed. **bitsandbytes** is a pinned community Windows ROCm wheel from [0xDELUXA/bitsandbytes_win_rocm](https://github.com/0xDELUXA/bitsandbytes_win_rocm) — built by neither AMD nor Fizgig. Shared deps come from `requirements.txt` with CUDA `torch`/`bitsandbytes` and NVIDIA-only `nvidia-ml-py` filtered out (`filter_requirements_rocm.py`). Launch with `run_fizgig_rocm.bat`. On **gfx1200 / gfx1201** (RDNA4), the launcher sets `ROCBLAS_USE_HIPBLASLT_BATCHED=0` so batched GEMMs use Tensile ([ROCm#5344](https://github.com/ROCm/ROCm/issues/5344)); opt out with `FIZGIG_NO_ROCBLAS_BATCHED_WA=1`. Do **not** set `ROCBLAS_USE_HIPBLASLT=0` on current nightlies — that path regresses.
+Override with `TORCH_PIN` / `TORCHVISION_PIN` / `ROCM_SDK_DEVEL_PIN` if needed. **bitsandbytes** is a pinned community Windows ROCm wheel from [0xDELUXA/bitsandbytes_win_rocm](https://github.com/0xDELUXA/bitsandbytes_win_rocm) — built by neither AMD nor Fizgig. Shared deps come from `requirements.txt` with CUDA `torch`/`bitsandbytes` and NVIDIA-only `nvidia-ml-py` filtered out (`filter_requirements_rocm.py`). Launch with `run_fizgig_rocm.bat`.
 
 **`--experimental` (unsupported):** `install_fizgig_rocm.bat --experimental` installs unpinned `torch[device-ARCH]` / `torchvision[device-ARCH]` / `rocm-sdk-devel` from the same multi-arch index and leaves `BNB_ROCM_VERSION` unset so bitsandbytes auto-selects its highest matching DLL. This is **not** the same as Linux `ROCM_CHANNEL=nightly` (which stays on the constrained 7.14 / bitsandbytes 714 lane). Windows already installs from AMD nightlies with pinned versions by default; `--experimental` only drops those pins. Local experimentation only. **Do not open GitHub issues for crashes, install failures, or training problems when `--experimental` was used** — those reports will not be supported. Use the pinned install (no flag) for anything you expect help with.
 
@@ -351,7 +351,7 @@ ROCM_CHANNEL=nightly TORCH_NIGHTLY_MINOR=2.14 ./install_fizgig_rocm.sh
 # (paired torchvision ~0.29.0a0+rocm7.14.0a… — installer resolves the match)
 ```
 
-Linux ROCm cache scripts import `fizgig.rocm.cache_exit` only when `FIZGIG_GPU_BACKEND=rocm` (set by `run_fizgig_rocm.sh`); NVIDIA and other platforms call `main()` unchanged. Opt out: `FIZGIG_ROCM_NO_FAST_EXIT=1 ./run_fizgig_rocm.sh`. Same gfx12 batched-GEMM workaround as Windows (`ROCBLAS_USE_HIPBLASLT_BATCHED=0`); opt out: `FIZGIG_NO_ROCBLAS_BATCHED_WA=1`.
+Linux ROCm cache scripts import `fizgig.rocm.cache_exit` only when `FIZGIG_GPU_BACKEND=rocm` (set by `run_fizgig_rocm.sh`); NVIDIA and other platforms call `main()` unchanged. Opt out: `FIZGIG_ROCM_NO_FAST_EXIT=1 ./run_fizgig_rocm.sh`.
 
 Then shared deps from `requirements.txt` (filtered) and `bitsandbytes>=0.50.0` for ROCm.
 

--- a/docs/RELEASE_NOTES_v4.3.0.md
+++ b/docs/RELEASE_NOTES_v4.3.0.md
@@ -12,8 +12,7 @@ Fizgig runs on AMD Radeon with ROCm — RDNA1 through RDNA4, Strix Point / Halo,
   launch with `run_fizgig_rocm.bat`. The installer detects your GPU and pulls the right wheels.
 - **Linux** is available but highly experimental — driver resets and crashes are common on newer
   cards. Use Windows ROCm or NVIDIA Linux for production training.
-- The status-bar VRAM readout works on AMD too, and RDNA4 cards get a known ROCm GEMM slowdown
-  worked around automatically.
+- The status-bar VRAM readout works on AMD too.
 - Full install details are in the README. NVIDIA installs are completely untouched — the AMD
   path is separate files, separate venv steps.
 

--- a/run_fizgig_rocm.bat
+++ b/run_fizgig_rocm.bat
@@ -11,7 +11,7 @@ set "PYTORCH_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512,garbage_c
 set "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1"
 set "FIZGIG_GPU_BACKEND=rocm"
 
-REM BNB_ROCM_VERSION / ROCM_PATH / HIP_PATH / gfx12 batched-GEMM wa - written by
+REM BNB_ROCM_VERSION / ROCM_PATH / HIP_PATH - written by
 REM install_fizgig_rocm.bat / write_rocm_env.py (not on every launch; re-run write_rocm_env.py
 REM after a pull if rocm_env.bat is stale).
 if exist "%~dp0rocm_env.bat" (
@@ -30,17 +30,12 @@ if defined ROCM_PATH if exist "%ROCM_PATH%\bin" set "PATH=%ROCM_PATH%\bin;%PATH%
 if exist "%~dp0venv\Lib\site-packages\_rocm_sdk_devel\bin" set "PATH=%~dp0venv\Lib\site-packages\_rocm_sdk_devel\bin;%PATH%"
 if exist "%~dp0venv\Scripts" set "PATH=%~dp0venv\Scripts;%PATH%"
 
-REM Opt out of gfx12 ROCBLAS_USE_HIPBLASLT_BATCHED=0 from rocm_env.bat:
-REM   set FIZGIG_NO_ROCBLAS_BATCHED_WA=1
-if defined FIZGIG_NO_ROCBLAS_BATCHED_WA set "ROCBLAS_USE_HIPBLASLT_BATCHED="
+set "ROCBLAS_USE_HIPBLASLT_BATCHED="
 
 if defined BNB_ROCM_VERSION (
     echo [AMD-ROCm] BNB_ROCM_VERSION=%BNB_ROCM_VERSION%  ROCM_PATH=%ROCM_PATH%
 ) else (
     echo [AMD-ROCm] BNB_ROCM_VERSION unset ^(bitsandbytes selects DLL^)  ROCM_PATH=%ROCM_PATH%
-)
-if defined ROCBLAS_USE_HIPBLASLT_BATCHED (
-    echo [AMD-ROCm] ROCBLAS_USE_HIPBLASLT_BATCHED=%ROCBLAS_USE_HIPBLASLT_BATCHED% ^(gfx12 batched GEMM wa^)
 )
 
 start "" /b wscript //nologo //b "%~dp0run_silent.vbs"

--- a/run_fizgig_rocm.sh
+++ b/run_fizgig_rocm.sh
@@ -16,7 +16,7 @@ export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
 export FIZGIG_GPU_BACKEND=rocm
 # Cache fast-exit: src/fizgig/rocm/cache_exit.py (Linux ROCm only). Opt out: FIZGIG_ROCM_NO_FAST_EXIT=1
 
-# BNB_ROCM_VERSION / ROCM_PATH / HIP_PATH / gfx12 batched-GEMM wa - write_rocm_env.py
+# BNB_ROCM_VERSION / ROCM_PATH / HIP_PATH - write_rocm_env.py
 # (install / first launch only; re-run write_rocm_env.py after a pull if rocm_env.sh is stale).
 if [[ -f rocm_env.sh ]]; then
     # shellcheck source=rocm_env.sh
@@ -55,19 +55,12 @@ for _lib in venv/lib/python*/site-packages/_rocm_sdk_core/lib \
 done
 export LD_LIBRARY_PATH
 
-# Opt out of gfx12 ROCBLAS_USE_HIPBLASLT_BATCHED=0 from rocm_env.sh:
-#   FIZGIG_NO_ROCBLAS_BATCHED_WA=1 ./run_fizgig_rocm.sh
-if [[ -n "${FIZGIG_NO_ROCBLAS_BATCHED_WA:-}" ]]; then
-    unset ROCBLAS_USE_HIPBLASLT_BATCHED
-fi
+unset ROCBLAS_USE_HIPBLASLT_BATCHED
 
 if [[ -n "${BNB_ROCM_VERSION:-}" ]]; then
     echo "[AMD-ROCm] BNB_ROCM_VERSION=${BNB_ROCM_VERSION}  ROCM_PATH=${ROCM_PATH:-}"
 else
     echo "[AMD-ROCm] BNB_ROCM_VERSION unset (bitsandbytes selects lib)  ROCM_PATH=${ROCM_PATH:-}"
-fi
-if [[ -n "${ROCBLAS_USE_HIPBLASLT_BATCHED:-}" ]]; then
-    echo "[AMD-ROCm] ROCBLAS_USE_HIPBLASLT_BATCHED=${ROCBLAS_USE_HIPBLASLT_BATCHED} (gfx12 batched GEMM wa)"
 fi
 
 python lora_trainer_gui.py &

--- a/write_rocm_env.py
+++ b/write_rocm_env.py
@@ -4,10 +4,6 @@
 bitsandbytes needs BNB_ROCM_VERSION to match the ROCm SDK bundled with the PyTorch wheel
 (e.g. 714 for ROCm 7.14, 715 for 7.15). run_fizgig_rocm.bat and run_fizgig_rocm.sh source these.
 
-On gfx1200/gfx1201, also exports ROCBLAS_USE_HIPBLASLT_BATCHED=0 - Tensile for batched
-GEMMs (ROCm#5344). Blunt ROCBLAS_USE_HIPBLASLT=0 is NOT set (hurts ROCm 7.15). Opt out at
-launch: FIZGIG_NO_ROCBLAS_BATCHED_WA=1.
-
 With --experimental (Windows floating install): omit BNB_ROCM_VERSION so bitsandbytes
 auto-selects its highest matching lib (falls back with a warning if exact ROCm minor is
 missing). Distinct from Linux ROCM_CHANNEL=nightly.
@@ -26,8 +22,6 @@ OUT_BAT = SCRIPT_DIR / "rocm_env.bat"
 OUT_SH = SCRIPT_DIR / "rocm_env.sh"
 DEFAULT_BNB_LINUX = "714"  # libbitsandbytes_rocm714.so - matches stable repo.amd.com torch
 DEFAULT_BNB_WIN = "715"  # Windows 0xDELUXA wheel / pinned multi-arch torch (+rocm7.15)
-# Batched hipBLASLt GEMM underperforms on RDNA4 - see ROCm/ROCm#5344.
-GFX12_HIPBLASLT_BATCHED_WA = frozenset({"gfx1200", "gfx1201"})
 
 
 def _bnb_lib_ext() -> str:
@@ -211,7 +205,6 @@ def main(argv: list[str] | None = None) -> int:
         src = f"{src}; BNB_ROCM_VERSION omitted (--experimental / bitsandbytes auto)"
 
     gfx = detect_gfx_target()
-    gfx12_batched_wa = gfx in GFX12_HIPBLASLT_BATCHED_WA if gfx else False
 
     rocm_core_win = SCRIPT_DIR / "venv" / "Lib" / "site-packages" / "_rocm_sdk_core"
     try:
@@ -243,16 +236,10 @@ def main(argv: list[str] | None = None) -> int:
             bat_lines.append(f'set "PATH={path_prefix};%PATH%"')
         if gfx:
             bat_lines.append(f'REM GPU gfx target: {gfx}')
-        if gfx12_batched_wa:
-            bat_lines.append(
-                "REM gfx12: Tensile for batched GEMM (ROCm#5344). "
-                "Opt out: set FIZGIG_NO_ROCBLAS_BATCHED_WA=1 before launch."
-            )
-            bat_lines.append('set "ROCBLAS_USE_HIPBLASLT_BATCHED=0"')
         bat_lines.append("")
         OUT_BAT.write_text("\r\n".join(bat_lines), encoding="utf-8")
         bnb_msg = "BNB_ROCM_VERSION unset" if omit_bnb else f"BNB_ROCM_VERSION={bnb}"
-        extra = f"  gfx={gfx}  ROCBLAS_USE_HIPBLASLT_BATCHED=0" if gfx12_batched_wa else (f"  gfx={gfx}" if gfx else "")
+        extra = f"  gfx={gfx}" if gfx else ""
         print(f"Wrote {OUT_BAT.name}: {bnb_msg}  ({src}){extra}")
 
     if rocm_core_linux is not None:
@@ -274,16 +261,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         if gfx:
             sh_lines.append(f"# GPU gfx target: {gfx}")
-        if gfx12_batched_wa:
-            sh_lines.append(
-                "# gfx12: Tensile for batched GEMM (ROCm#5344). "
-                "Opt out: FIZGIG_NO_ROCBLAS_BATCHED_WA=1"
-            )
-            sh_lines.append('export ROCBLAS_USE_HIPBLASLT_BATCHED=0')
         sh_lines.append("")
         OUT_SH.write_text("\n".join(sh_lines), encoding="utf-8")
         bnb_msg = "BNB_ROCM_VERSION unset" if omit_bnb else f"BNB_ROCM_VERSION={bnb}"
-        extra = f"  gfx={gfx}  ROCBLAS_USE_HIPBLASLT_BATCHED=0" if gfx12_batched_wa else (f"  gfx={gfx}" if gfx else "")
+        extra = f"  gfx={gfx}" if gfx else ""
         print(f"Wrote {OUT_SH.name}: {bnb_msg}  ({src}){extra}")
 
     if not rocm_core_win.is_dir() and rocm_core_linux is None:


### PR DESCRIPTION
ROCm/legacy-rocm-build#53 auto-sets `ROCBLAS_USE_HIPBLASLT_BATCHED=0` on gfx1200 / gfx1201, citing ROCm/ROCm#5344. On a current stack that setting costs about 7.5x on the batched path, and for the trainer it does nothing at all.

Measured on gfx1200, torch 2.14.0a0+rocm10.1 nightly, rocBLAS 5.7.0, Windows. Calling `hipblasHgemmBatched` directly at fp16 b=32 1024^3: 53981 GFLOP/s unset against 7094 with the workaround, repeated with unset and bogus-variable controls interleaved. At default settings batched is already at parity with strided_batched, so the slowdown ROCm/ROCm#5344 describes does not reproduce here. Torch never reaches that path anyway: under `ROCBLAS_LAYER=1` it issues zero rocBLAS calls and goes straight to hipBLASLt, and when forced onto rocBLAS it uses `gemm_strided_batched`, never the pointer-array `gemm_batched` the issue is about. rocBLAS deprecated the variable in 5.6.0.

Removes the emit in `write_rocm_env.py`, the `FIZGIG_NO_ROCBLAS_BATCHED_WA` opt-out and status line in both launchers, and the claim from the README, release notes and CONTRIBUTORS.

`rocm_env.bat` / `rocm_env.sh` only regenerate when missing, so the launchers now clear the variable to unstick existing installs.
