### PR TITLE
Minimax preview: stills park the base for decode instead of OOMing every epoch

### DIFF
--- a/src/fizgig/minimax/trainer.py
+++ b/src/fizgig/minimax/trainer.py
@@ -3415,11 +3415,15 @@ def train_minimax(
                     from fizgig.utils.device import plannable_free_vram as _pfv
                     _free = _pfv()
                     vram_line("pre-decode")
-                    if _frames > 1 and _free < 7.5:
+                    if _free < 7.5:
+                        # Stills included, not just clips: the decoder does not fit beside
+                        # the resident base on a tight card regardless of frame count — the
+                        # old _frames > 1 guard was a big-card assumption that turned into
+                        # an every-epoch OOM for still previews.
                         _need = (7.5 - _free) + 1.0
-                        logger.info(f"[preview] {_free:.1f} GB free is too tight for clip "
-                                    f"decode — parking ~{_need:.1f} GB of tail blocks for "
-                                    f"this decode pass.")
+                        logger.info(f"[preview] {_free:.1f} GB free is too tight for "
+                                    f"{'clip ' if _frames > 1 else ''}decode — parking "
+                                    f"~{_need:.1f} GB of tail blocks for this decode pass.")
                         park_dit_partial(dit, need_gb=_need)
                         gc.collect()
                         torch.cuda.empty_cache()
@@ -3500,6 +3504,14 @@ def train_minimax(
             if _audio_dec_state["dec"] is not None:
                 _audio_dec_state["dec"].to("cpu")     # ~0.45 GB back off the card
             vram_line("post-decode")
+            if _base_parked and decoder is not None:
+                # The decoder must be off the card before the parked tail blocks
+                # come back — with it resident there is not enough room for the
+                # restore. Idempotent with the finally, which covers the exception path.
+                decoder.to("cpu")
+                gc.collect()
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
             if _base_parked:
                 restore_parked_dit(dit, device, n_swap)   # swap-aware: never the whole base
                 gc.collect()


### PR DESCRIPTION
Field report (16 GB card, int8 base + H2D block-swap 26, still 768x640): "Sample at Start failed (OutOfMemoryError)" — and previews died every epoch. Training itself ran fine (~1.35 s/it); only the previews kept dying quietly: one warning line in the log, then silence. The 4.85 GB decoder did not fit beside the resident base (allocated ~11 GB, driver free ~4.25 GB) — but the park guard "_frames > 1" let stills walk right past the parking, and "decoder.to(device)" asked for 4.85 GB with 4.25 to spare → OOM.

The two features were each right alone: the tail-block park before decode was written for clips, where decode transients run ~6 GB and nothing fits without it; for a single-frame still on a 32 GB card the decoder fit fine unparked, so "_frames > 1" read as an optimization — "why park for one frame when there is room?" And "restore_parked_dit", bringing the parked blocks back after decode, was written assuming the decoder had already left (the "finally" takes it off). They just could not tell each other apart: the park never fired for stills → the restore never ran → the second defect stayed invisible. Remove "_frames > 1" without reordering and the restore bumps straight into a decoder that is still sitting on the GPU.

- The park guard: "if _frames > 1 and _free < 7.5:" → "if _free < 7.5:" — stills now park the tail blocks whenever free VRAM drops below the threshold: on a tight card the decoder does not fit beside the resident base regardless of frame count.
- The restore order: the decoder is moved off the card before "restore_parked_dit" (decoder.to("cpu") + gc.collect() + empty_cache()) — without that, the restore needs the room the decoder itself occupies; idempotent with the "finally", which covers the exception path.

On 32 GB+ cards nothing changes: "_free > 7.5" always holds, none of the new lines execute (bit-for-bit identical to the old path). Training and checkpoints are never at risk — previews are a heartbeat between checkpoints, not the verdict.

On the 16 GB card, previews should now log [vram:pre-decode] → park ~2–3 GB of tail blocks → [vram:post-park] → decode → decoder off → restore → [vram:post-restore], with no OOM — and stop dying every epoch.