### PR TITLE
rocm: legacy RDNA1/2 SDP overrides and MIOpen/rocBLAS DB paths.

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -106,6 +106,11 @@ installer uses code from that project as follows:
   comfyui-rocm's `install.bat` (adapted for Fizgig's venv and
   requirements). The batch file itself is Apache-2.0; the bundled
   `detect_gpu.py` remains GPL-3.0.
+- `run_fizgig_rocm.bat` / `run_fizgig_rocm.sh` — Fizgig-authored launchers.
+  Legacy RDNA1/2 SDP overrides, aotriton gating, and MIOpen/rocBLAS tensile
+  DB path setup are adapted from comfyui-rocm's `comfyui-rocm.bat`. The
+  launchers themselves are Apache-2.0; Windows detection still goes through
+  the GPL-3.0 `detect_gpu.py` above.
 
 `detect_gpu.py` is free software: you may redistribute and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/run_fizgig_rocm.bat
+++ b/run_fizgig_rocm.bat
@@ -1,6 +1,7 @@
 @echo off
 REM Fizgig launcher for AMD ROCm on Windows.
-REM Sets ROCm/HIP tuning env vars, then starts the consoleless GUI chain.
+REM Sets ROCm/HIP tuning env vars (legacy RDNA1/2 vs newer), then starts the consoleless GUI.
+setlocal enabledelayedexpansion
 cd /d "%~dp0"
 
 echo [AMD-ROCm] Setting environment variables...
@@ -8,7 +9,6 @@ set "MIOPEN_FIND_MODE=2"
 set "FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE"
 REM expandable_segments mirrors upstream train scripts' CUDA alloc policy (ROCm key).
 set "PYTORCH_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512,garbage_collection_threshold:0.8"
-set "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1"
 set "FIZGIG_GPU_BACKEND=rocm"
 
 REM BNB_ROCM_VERSION / ROCM_PATH / HIP_PATH - written by
@@ -29,6 +29,40 @@ REM bitsandbytes cuda_specs runs "hipinfo" on Windows - lives under the pip ROCm
 if defined ROCM_PATH if exist "%ROCM_PATH%\bin" set "PATH=%ROCM_PATH%\bin;%PATH%"
 if exist "%~dp0venv\Lib\site-packages\_rocm_sdk_devel\bin" set "PATH=%~dp0venv\Lib\site-packages\_rocm_sdk_devel\bin;%PATH%"
 if exist "%~dp0venv\Scripts" set "PATH=%~dp0venv\Scripts;%PATH%"
+
+REM Detect gfx for legacy RDNA1/2 overrides and MIOpen/rocBLAS DB paths.
+set "GPU_ARCH="
+if exist "%~dp0venv\Scripts\python.exe" if exist "%~dp0detect_gpu.py" (
+    for /f "delims=" %%A in ('"%~dp0venv\Scripts\python.exe" "%~dp0detect_gpu.py" 2^>nul') do set "GPU_ARCH=%%A"
+)
+set "IS_LEGACY_GPU=0"
+if defined GPU_ARCH (
+    if /I "!GPU_ARCH:~0,6!"=="gfx101" set "IS_LEGACY_GPU=1"
+    if /I "!GPU_ARCH:~0,6!"=="gfx103" set "IS_LEGACY_GPU=1"
+)
+
+if "!IS_LEGACY_GPU!"=="1" (
+    echo [AMD-ROCm] Legacy GPU !GPU_ARCH! - RDNA1/2 SDP overrides ^(no aotriton experimental^)
+    set "TORCH_BACKENDS_CUDA_FLASH_SDP_ENABLED=0"
+    set "TORCH_BACKENDS_CUDA_MEM_EFF_SDP_ENABLED=0"
+    set "TORCH_BACKENDS_CUDA_MATH_SDP_ENABLED=1"
+) else (
+    if defined GPU_ARCH (
+        echo [AMD-ROCm] GPU arch: !GPU_ARCH!
+    ) else (
+        echo [AMD-ROCm] GPU arch: unknown
+    )
+    set "TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1"
+)
+
+REM MIOpen / rocBLAS tensile DBs live under _rocm_sdk_devel; skip on gfx1100
+REM where those trees are often missing.
+set "ROCM_DEVEL_BIN=%~dp0venv\Lib\site-packages\_rocm_sdk_devel\bin"
+if /I not "!GPU_ARCH!"=="gfx1100" (
+    if exist "!ROCM_DEVEL_BIN!" set "MIOPEN_SYSTEM_DB_PATH=!ROCM_DEVEL_BIN!"
+    if exist "!ROCM_DEVEL_BIN!\rocblas" set "ROCBLAS_TENSILE_DB_PATH=!ROCM_DEVEL_BIN!\rocblas"
+    if exist "!ROCM_DEVEL_BIN!\rocblas\library" set "ROCBLAS_TENSILE_LIBPATH=!ROCM_DEVEL_BIN!\rocblas\library"
+)
 
 set "ROCBLAS_USE_HIPBLASLT_BATCHED="
 

--- a/run_fizgig_rocm.sh
+++ b/run_fizgig_rocm.sh
@@ -12,7 +12,6 @@ export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
 export FIZGIG_NO_EXPANDABLE=1
 export PYTORCH_ALLOC_CONF=max_split_size_mb:512,garbage_collection_threshold:0.8
 export PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512,garbage_collection_threshold:0.8
-export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
 export FIZGIG_GPU_BACKEND=rocm
 # Cache fast-exit: src/fizgig/rocm/cache_exit.py (Linux ROCm only). Opt out: FIZGIG_ROCM_NO_FAST_EXIT=1
 
@@ -54,6 +53,48 @@ for _lib in venv/lib/python*/site-packages/_rocm_sdk_core/lib \
     [[ -d "$_lib" ]] && LD_LIBRARY_PATH="${_lib}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 done
 export LD_LIBRARY_PATH
+
+# Detect gfx for legacy RDNA1/2 overrides and MIOpen/rocBLAS DB paths.
+GPU_ARCH=""
+if [[ -x venv/bin/python && -f detect_gpu_linux.py ]]; then
+    GPU_ARCH="$(venv/bin/python detect_gpu_linux.py 2>/dev/null | tail -n1 | tr -d '[:space:]')" || true
+fi
+IS_LEGACY_GPU=0
+case "${GPU_ARCH}" in
+    gfx101*|gfx103*) IS_LEGACY_GPU=1 ;;
+esac
+
+if [[ "$IS_LEGACY_GPU" -eq 1 ]]; then
+    echo "[AMD-ROCm] Legacy GPU ${GPU_ARCH} - RDNA1/2 SDP overrides (no aotriton experimental)"
+    export TORCH_BACKENDS_CUDA_FLASH_SDP_ENABLED=0
+    export TORCH_BACKENDS_CUDA_MEM_EFF_SDP_ENABLED=0
+    export TORCH_BACKENDS_CUDA_MATH_SDP_ENABLED=1
+    unset TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL
+else
+    if [[ -n "$GPU_ARCH" ]]; then
+        echo "[AMD-ROCm] GPU arch: ${GPU_ARCH}"
+    else
+        echo "[AMD-ROCm] GPU arch: unknown"
+    fi
+    export TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+fi
+
+# MIOpen / rocBLAS tensile DBs under _rocm_sdk_devel; skip on gfx1100
+# where those trees are often missing.
+if [[ "${GPU_ARCH}" != "gfx1100" ]]; then
+    for _devel in venv/lib/python*/site-packages/_rocm_sdk_devel/bin; do
+        if [[ -d "$_devel" ]]; then
+            export MIOPEN_SYSTEM_DB_PATH="$(cd "$_devel" && pwd)"
+            if [[ -d "$_devel/rocblas" ]]; then
+                export ROCBLAS_TENSILE_DB_PATH="$(cd "$_devel/rocblas" && pwd)"
+            fi
+            if [[ -d "$_devel/rocblas/library" ]]; then
+                export ROCBLAS_TENSILE_LIBPATH="$(cd "$_devel/rocblas/library" && pwd)"
+            fi
+            break
+        fi
+    done
+fi
 
 unset ROCBLAS_USE_HIPBLASLT_BATCHED
 


### PR DESCRIPTION
Detect gfx at launch; skip aotriton experimental on gfx101/gfx103, set tensile DB paths except on gfx1100, and note the comfyui-rocm adaptation in THIRD_PARTY_NOTICES.

Might fix / helps with https://github.com/shootthesound/Fizgig/issues/127